### PR TITLE
Fixed/34

### DIFF
--- a/src/rdetoolkit/invoicefile.py
+++ b/src/rdetoolkit/invoicefile.py
@@ -37,6 +37,8 @@ def read_excelinvoice(excelinvoice_filepath: RdeFsPath) -> tuple[pd.DataFrame, p
     df_general = None
     df_specific = None
     for sh_name, df in dct_sheets.items():
+        if df.empty:
+            continue
         if df.iat[0, 0] == "invoiceList_format_id":
             if dfexcelinvoice is not None:
                 emsg = "ERROR: multiple sheet in invoiceList files"

--- a/src/rdetoolkit/invoicefile.py
+++ b/src/rdetoolkit/invoicefile.py
@@ -330,6 +330,8 @@ class ExcelInvoiceFile:
         df_general = None
         df_specific = None
         for sh_name, df in dct_sheets.items():
+            if df.empty:
+                continue
             if df.iat[0, 0] == "invoiceList_format_id":
                 if dfexcelinvoice is not None:
                     emsg = "ERROR: multiple sheet in invoiceList files"

--- a/src/rdetoolkit/invoicefile.py
+++ b/src/rdetoolkit/invoicefile.py
@@ -320,19 +320,17 @@ class ExcelInvoiceFile:
         if target_path is None:
             target_path = self.invoice_path
 
-        if not os.path.exists(target_path):
-            emsg = f"ERROR: excelinvoice not found {target_path}"
-            raise StructuredError(emsg)
+        self.__check_exist_rawfiles(target_path)
 
         dct_sheets = pd.read_excel(target_path, sheet_name=None, dtype=str, header=None, index_col=None)
 
-        dfexcelinvoice = None
-        df_general = None
-        df_specific = None
+        dfexcelinvoice, df_general, df_specific = None, None, None
         for sh_name, df in dct_sheets.items():
             if df.empty:
                 continue
-            if df.iat[0, 0] == "invoiceList_format_id":
+
+            target_comment_value = df.iat[0, 0]
+            if target_comment_value == "invoiceList_format_id":
                 if dfexcelinvoice is not None:
                     emsg = "ERROR: multiple sheet in invoiceList files"
                     raise StructuredError(emsg)
@@ -365,6 +363,11 @@ class ExcelInvoiceFile:
         _df_specific = df[1:].copy()
         _df_specific.columns = ["sample_class_id", "term_id", "key_name"]
         return _df_specific
+
+    def __check_exist_rawfiles(self, excel_rawfiles: Path) -> None:
+        if not os.path.exists(excel_rawfiles):
+            emsg = f"ERROR: excelinvoice not found {excel_rawfiles}"
+            raise StructuredError(emsg)
 
     def overwrite(self, invoice_org: Path, dist_path: Path, invoice_schema_path: Path, idx: int) -> None:
         """Overwrites the content of the original invoice file based on the data from the Excel invoice and saves it as a new file.

--- a/tests/fixtures/excelinvoice.py
+++ b/tests/fixtures/excelinvoice.py
@@ -993,7 +993,7 @@ EXCELINVOICE_ENTRYDATA_SHEET3 = [
 
 @pytest.fixture
 def inputfile_single_excelinvoice() -> Generator[str, None, None]:
-    """ExcelInvoice / One input file"""
+    """ExcelInvoice / One input file / add empty sheet"""
     input_dir = pathlib.Path("data", "inputdata")
     input_dir.mkdir(parents=True, exist_ok=True)
     test_excel_invoice = pathlib.Path(input_dir, "test_excel_invoice.xlsx")
@@ -1002,11 +1002,13 @@ def inputfile_single_excelinvoice() -> Generator[str, None, None]:
         EXCELINVOICE_ENTRYDATA_SHEET1_SINGLE,
         columns=["invoiceList_format_id", "Sample_RDE_DataSet", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""],
     )
+    empty_df = pd.DataFrame()
     df2 = pd.DataFrame(EXCELINVOICE_ENTRYDATA_SHEET2, columns=["term_id", "key_name"])
     df3 = pd.DataFrame(EXCELINVOICE_ENTRYDATA_SHEET3, columns=["sample_class_id", "term_id", "key_name"])
 
     with pd.ExcelWriter(test_excel_invoice) as writer:
         df1.to_excel(writer, sheet_name="invoice_form", index=False)
+        empty_df.to_excel(writer, sheet_name="empty_sheet", index=False)
         df2.to_excel(writer, sheet_name="generalTerm", index=False)
         df3.to_excel(writer, sheet_name="specificTerm", index=False)
 

--- a/tests/test_invoicefile.py
+++ b/tests/test_invoicefile.py
@@ -323,6 +323,7 @@ def test_update_description_none_features_none_variable(
 def test_read_excelinvoice(inputfile_single_excelinvoice):
     """read_excelinvoiceのテスト
     dfexcelinvoice, df_general, dfSpecificが正しい値で返ってくるかテスト
+    また、空のシートが含まれるエクセルインボイスを入れた時に想定通りの値を出力するかテスト
     """
     expect_sheet1 = [
         [

--- a/tests/test_invoicefile.py
+++ b/tests/test_invoicefile.py
@@ -385,9 +385,6 @@ def test_read_excelinvoice(inputfile_single_excelinvoice):
 
     dfexcelinvoice, df_general, df_specific = read_excelinvoice(inputfile_single_excelinvoice)
 
-    print(dfexcelinvoice)
-    print(df1)
-
     assert_frame_equal(dfexcelinvoice, df1)
     assert isinstance(df_general, pd.DataFrame)
     assert df_general.columns.to_list() == ["term_id", "key_name"]
@@ -471,3 +468,92 @@ def test_apply_magic_variable_inputfile_check(ivnoice_json_magic_filename_variab
     result = apply_magic_variable(invoice_path, rawfile_path)
 
     assert result["basic"]["dataName"] == "dymmy_replace_filename.txt"
+
+
+class TestExcelinvoice:
+    """Excelinvoiceクラスのテスト"""
+
+    def test_read(self, inputfile_single_excelinvoice):
+        """read_excelinvoiceのテスト
+        dfexcelinvoice, df_general, dfSpecificが正しい値で返ってくるかテスト
+        また、空のシートが含まれるエクセルインボイスを入れた時に想定通りの値を出力するかテスト
+        """
+        expect_sheet1 = [
+            [
+                "test_child1.txt",
+                "N_TEST_1",
+                "test_user",
+                "de17c7b3f0ff5126831c2d519f481055ba466ddb6238666132316439",
+                "test1",
+                "ee17c7b3-f0ff-5126-831c-2d519f481055",
+                "test_230606_1",
+                "https://sample.com",
+                "desc1",
+                "sample1",
+                "de17c7b3-f0ff-5126-831c-2d519f481055",
+                "de17c7b3f0ff5126831c2d519f481055ba466ddb6238666132316439",
+                "sample1",
+                "https://sample.com",
+                "desc3",
+                "testname",
+                "Fe",
+                "magnet",
+                "7439-89-6",
+                "7439-89-6",
+                "7439-89-6",
+                "7439-89-6",
+                "AAA",
+                "CCC",
+            ],
+        ]
+        df1 = pd.DataFrame(
+            expect_sheet1,
+            columns=[
+                "data_file_names/name",
+                "dataset_title",
+                "dataOwner",
+                "basic/dataOwnerId",
+                "basic/dataName",
+                "basic/instrumentId",
+                "basic/experimentId",
+                "basic/referenceUrl",
+                "basic/description",
+                "sample/names",
+                "sample/sampleId",
+                "sample/ownerId",
+                "sample/composition",
+                "sample/referenceUrl",
+                "sample/description",
+                "sample.general/general-name",
+                "sample.general/cas-number",
+                "sample.general/crystal-structure",
+                "sample.general/purchase-date",
+                "sample.general/lot-number-or-product-number-etc",
+                "sample.general/smiles-string",
+                "sample.general/supplier",
+                "custom/key1",
+                "custom/key2",
+            ],
+        )
+
+        excelinvoice = ExcelInvoiceFile(inputfile_single_excelinvoice)
+        dfexcelinvoice, df_general, df_specific = excelinvoice.read()
+        assert_frame_equal(dfexcelinvoice, df1)
+        assert isinstance(df_general, pd.DataFrame)
+        assert df_general.columns.to_list() == ["term_id", "key_name"]
+        assert isinstance(df_specific, pd.DataFrame)
+        assert df_specific.columns.to_list() == ["sample_class_id", "term_id", "key_name"]
+
+    def test_read_emptyfile(self, empty_inputfile_excelinvoice):
+        """空のエクセルインボイスを入れた時に例外をキャッチできるかテスト"""
+        with pytest.raises(StructuredError) as e:
+            excelinvoice = ExcelInvoiceFile(empty_inputfile_excelinvoice)
+            _, _, _ = excelinvoice.read()
+        assert str(e.value) == "ERROR: no sheet in invoiceList files"
+
+    def test_invalidfile_read(self, inputfile_invalid_samesheet_excelinvoice):
+        """sheet1の内容が複数あるエクセルインボイスを入れた時に例外をキャッチできるかテスト"""
+        with pytest.raises(StructuredError) as e:
+            excelinvoice = ExcelInvoiceFile(inputfile_invalid_samesheet_excelinvoice)
+            _, _, _ = excelinvoice.read()
+        assert str(e.value) == "ERROR: multiple sheet in invoiceList files"


### PR DESCRIPTION
## issue
<!--関連issueを記載する-->
#34 エクセルインボイスモードで、Excelファイルに空のシートがあるとエラーになる

## 変更内容
<!--対応内容や変更内容を記載する-->
Excelinvoiceに空のシートが含まれていた場合エラーが発生するため、空シートが含まれていた場合、処理対象に含めないように変更。

## 検証内容
<!--プルリクで確認する内容を列挙する-->

- [x] CIのテストがパスする
    - 追加したテストケースがパスするか確認する: `tests/test_invoicefile.py::test_read_excelinvoice`
- [x] 対象のスクリプトの変更に問題がないか
