### PR TITLE
Feature/40 update Python3.12

### DIFF
--- a/.github/workflows/coverage_badge.yml
+++ b/.github/workflows/coverage_badge.yml
@@ -28,9 +28,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           echo "Debug: ${GITHUB_REF_NAME}"
-          git stash
           git pull origin ${GITHUB_REF_NAME} --rebase
-          git stash pop
           if (git diff --shortstat | grep '[0-9]'); then
             git add docs/img/coverage.svg
             git commit -m "[Auto] Update coverage badge based on latest test results"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         tox-env: [module, ruff, lizard, mypy]
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install build
+          pip install build setuptools
       - name: Build
         run: python -m build
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -13,10 +13,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install pypa/build
         run: |
-          python3 -m pip install build --user
+          python3 -m pip install build setuptools --user
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "charset-normalizer>=3.2.0",
     "matplotlib>=3.7.2",
     "openpyxl>=3.1.2",
-    "pandas>=2.0.3",
+    "pandas==2.2.0",
     "build>=1.0.3",
     "click>=8.1.7",
     "toml>=0.10.2",
@@ -18,6 +18,7 @@ dependencies = [
     "tomlkit>=0.12.4",
     "PyYAML>=6.0.1",
     "eval_type_backport>=0.2.0",
+    "numpy==1.26.4",
 ]
 readme = "README.md"
 requires-python = ">= 3.9"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -69,11 +69,11 @@ mkdocstrings-python==1.7.5
 mypy==1.5.1
 mypy-extensions==1.0.0
 nodeenv==1.8.0
-numpy==1.25.2
+numpy==1.26.4
 openpyxl==3.1.2
 packaging==23.1
 paginate==0.5.6
-pandas==2.1.0
+pandas==2.2.0
 pathspec==0.11.2
 pillow==10.0.0
 platformdirs==3.10.0
@@ -117,4 +117,4 @@ virtualenv==20.24.5
 watchdog==3.0.0
 zipp==3.16.2
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==69.0.3
+setuptools==75.1.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -27,10 +27,10 @@ jsonschema==4.21.1
 jsonschema-specifications==2023.12.1
 kiwisolver==1.4.5
 matplotlib==3.7.3
-numpy==1.25.2
+numpy==1.26.4
 openpyxl==3.1.2
 packaging==23.1
-pandas==2.1.0
+pandas==2.2.0
 pillow==10.0.0
 pydantic==2.6.3
 pydantic-core==2.16.3

--- a/src/rdetoolkit/rde2util.py
+++ b/src/rdetoolkit/rde2util.py
@@ -694,24 +694,16 @@ def castval(valstr: Any, outtype: str | None, outfmt: str | None) -> bool | int 
         if ValueCaster.trycast(valstr, bool) is not None:
             return bool(valstr)
 
-    elif outtype == "integer":
+    elif outtype in ("integer", "number"):
         # Even if a string with units is passed, the assignment of units is not handled in this function. Assign units separately as necessary.
         val_unit_pair = _split_value_unit(valstr)
         if ValueCaster.trycast(val_unit_pair.value, int) is not None:
             return int(val_unit_pair.value)
-
-    elif outtype == "number":
-        # Even if a string with units is passed, the assignment of units is not handled in this function. Assign units separately as necessary.
-        val_unit_pair = _split_value_unit(valstr)
-        if ValueCaster.trycast(val_unit_pair.value, int) is not None:
-            return int(val_unit_pair.value)
-        if ValueCaster.trycast(val_unit_pair.value, float) is not None:
+        if outtype == "number" and ValueCaster.trycast(val_unit_pair.value, float) is not None:
             return float(val_unit_pair.value)
 
     elif outtype == "string":
-        if not outfmt:
-            return valstr
-        return ValueCaster.convert_to_date_format(valstr, outfmt)
+        return valstr if not outfmt else ValueCaster.convert_to_date_format(valstr, outfmt)
 
     else:
         emsg = "ERROR: unknown value type in metaDef"

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 skipsdist = True
 envlist =
-    py3{9,10,11}-{module,ruff,lizard,mypy}
-    flake8
+    py3{9,10,11,12}-{module,ruff,lizard,mypy}
+    ruff
     mypy
+    lizard
 skip_missing_interpreters = True
 
 [testenv]
@@ -31,6 +32,13 @@ deps = -rrequirements-dev.lock
 commands =
     python3 -m pytest --cov-config=pyproject.toml --cov=. --cov-report=html --cov-report=xml --cov-report=term-missing tests
 
+[testenv:py312-module]
+deps =
+    setuptools
+    -rrequirements-dev.lock
+commands =
+    python3 -m pytest --cov-config=pyproject.toml --cov=. --cov-report=html --cov-report=xml --cov-report=term-missing tests
+
 [testenv:ruff]
 skip_install = true
 deps = -rrequirements-dev.lock
@@ -52,6 +60,14 @@ commands =
 [testenv:py311-ruff]
 skip_install = true
 deps = -rrequirements-dev.lock
+commands =
+  ruff check src/rdetoolkit/
+
+[testenv:py312-ruff]
+skip_install = true
+deps =
+    setuptools
+    -rrequirements-dev.lock
 commands =
   ruff check src/rdetoolkit/
 
@@ -88,6 +104,17 @@ commands =
   lizard src/rdetoolkit/__main__.py -C 10
   lizard src/rdetoolkit/  -C 9 -x src/rdetoolkit/rde2util.py -x src/rdetoolkit/__main__.py
 
+[testenv:py312-lizard]
+skip_install = true
+deps =
+    setuptools
+    -rrequirements-dev.lock
+commands =
+  # Due to not having been able to refactor.
+  lizard src/rdetoolkit/rde2util.py -C 10
+  lizard src/rdetoolkit/__main__.py -C 10
+  lizard src/rdetoolkit/  -C 9 -x src/rdetoolkit/rde2util.py -x src/rdetoolkit/__main__.py
+
 [testenv:mypy]
 skip_install = true
 deps = -rrequirements-dev.lock
@@ -109,5 +136,13 @@ commands =
 [testenv:py311-mypy]
 skip_install = true
 deps = -rrequirements-dev.lock
+commands =
+  mypy src/
+
+[testenv:py312-mypy]
+skip_install = true
+deps =
+    setuptools
+    -rrequirements-dev.lock
 commands =
   mypy src/


### PR DESCRIPTION
## issue
<!--関連issueを記載する-->

- #40 Python3.12対応
- #42 Numpyのアップデート
- #43 pandasのアップデート

## 変更内容
<!--対応内容や変更内容を記載する-->

rdetoolkitを3.12へアップデートするためテストコードの更新と確認を実施。この変更により以下のパッケージのバージョンを変更した。

- `numpy==1.26.0`: python3.12が1.26.0以上のバージョンしか対応していないため。
- `pandas==2.2.0`: 従来の2.1.0では、python3.12へアップデートすると動作しない不具合が発生したため。

主に変更したファイルは以下の通り。

- `tox.ini`
- `.github/workflows/main.yml`
- `.github/workflows/pypi-release.yml`

また、今回のスコープ対象外だが、複雑度CCNが10以上になりテストが通らなかったため、`src/rdetoolkit/rde2util.py`をリファクタリングを実施した。

> [changed: #40 Refactor value casting logic in rde2util.py](https://github.com/nims-dpfc/rdetoolkit/commit/cbd4392696890e4ea79582a14e892ce935dc7411)

## 検証内容
<!--プルリクで確認する内容を列挙する-->

- [x] CIのテストがパスする
- [x] 対象のスクリプトの変更に問題がないか
