### PR TITLE
Develop/41

### DIFF
--- a/docs/rdetoolkit/config.md
+++ b/docs/rdetoolkit/config.md
@@ -1,9 +1,5 @@
 # config
 
-## Config
-
-::: src.rdetoolkit.config.Config
-
 ## parse_config_file
 
 ::: src.rdetoolkit.config.parse_config_file

--- a/docs/rdetoolkit/models/config.md
+++ b/docs/rdetoolkit/models/config.md
@@ -1,0 +1,5 @@
+# config
+
+## Config
+
+::: src.rdetoolkit.models.config.Config

--- a/docs/usage/config/config.md
+++ b/docs/usage/config/config.md
@@ -3,7 +3,7 @@
 rdetoolkitでは、起動時の挙動を設定ファイルで制御することは可能です。
 
 !!! Reference
-    API Documents: [rdetoolkit.config.parse_config_file](../../rdetoolkit/config.md/#parse_config_file)
+    API Documents: [rdetoolkit.config.parse_config_file](/rdetoolkit/config/#parse_config_file)
 
 ## 設定ファイル
 
@@ -105,6 +105,16 @@ rdetoolkitでは、4つの起動モードをサポートしています。
     save_thumbnail_image: false
     ```
 
+### 独自の設定値を設定する
+
+`rdeconfig.yaml`等の設定ファイルは、ユーザー独自の設定値を記述することができます。例えば、サムネイルの画像にどのファイルにするか指定する場合、`thumbnail_image_name`という設定値を以下のように記述します。
+
+    ```yaml
+    thumbnail_image_name: "inputdata/sample_image.png"
+    ```
+
+> 設定値の書き方については、YAMLフォーマットに従って記述してください。: [YAML Ain’t Markup Language (YAML™) version 1.2](https://yaml.org/spec/1.2.2/)
+
 ## 設定ファイルの設定例
 
 === "rdeconfig.yml"
@@ -124,4 +134,29 @@ rdetoolkitでは、4つの起動モードをサポートしています。
     save_raw = true
     magic_variable = false
     save_thumbnail_image = true
+    ```
+
+### 構造化処理から設定値を参照する
+
+構造化処理内で、`tasksupport`に格納した設定値を参照する方法は、`rdetoolkit.models.rde2types.RdeInputDirPaths.config`で設定値を参照できます。
+
+    ```python
+    def dataset(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePath):
+        # この関数内でユーザ自身が定義したクラスや関数を記述する
+        ... #任意の処理
+
+        # Extendeds Modeの設定値を取得する
+        print(srcpaths.config.extended_mode)
+
+        # 入力ファイルの自動保存の設定値を取得する
+        print(srcpaths.config.save_raw)
+
+        # サムネイル画像の自動保存の設定値を参照する
+        print(srcpaths.config.save_thumbnail_image)
+
+        # magic variableの設定値を参照する
+        print(srcpaths.config.magic_variable)
+
+        # 独自に定義した設定値を参照する場合: thumbnail_image_name
+        print(srcpaths.config.magic_variable)
     ```

--- a/docs/usage/config/file_folder_mode.md
+++ b/docs/usage/config/file_folder_mode.md
@@ -56,4 +56,4 @@ Excelinvoiceに表記したモードと、入力するzipファイルの構成�
 この処理は、RdeToolKitで定義しています。該当ソースコードは以下のリポジトリのリンクを参照してください。
 
 !!! Reference
-    - [parse_compressedfile_mode - compressed_controller](../../rdetoolkit/impl/compressed_controller.md/#parse_compressedfile_mode)
+    - [parse_compressedfile_mode - compressed_controller](/rdetoolkit/impl/compressed_controller/#parse_compressedfile_mode)

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -62,7 +62,7 @@ graph LR
 起動処理、終了処理は、rdetoolkitを使うことで簡単に実行できます。そのため、ユーザー自身は、ご自身のデータに対する処理を実行する **カスタム構造化処理** を定義するだけです。
 
 !!! Tip "Documents"
-    [カスタム用構造化処理関数の作成](structured.md/#_5)
+    [カスタム用構造化処理関数の作成](./structured_process/structured.md/#_5)
 
 ### カスタム用構造化処理関数の作成
 
@@ -79,8 +79,8 @@ def dataset(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePath):
 ```
 
 !!! Reference
-    - API Documentation: [RdeInputDirPaths - rde2types](rdetoolkit/models/rde2types.md/#rdeinputdirpaths)
-    - API Documentation: [RdeOutputResourcePath - rde2types](rdetoolkit/models/rde2types.md/#rdeoutputresourcepath)
+    - API Documentation: [RdeInputDirPaths - rde2types](/rdetoolkit/models/rde2types/#rdeinputdirpaths)
+    - API Documentation: [RdeOutputResourcePath - rde2types](/rdetoolkit/models/rde2types/#rdeoutputresourcepath)
 
 今回の例では、`modules`以下に、`display_messsage()`, `custom_graph()`, `custom_extract_metadata()`というダミー処理を定義し、独自の構造化処理を定義します。これらの関数は、`modules/modules.py`というファイルを作成し定義します。以下の2つの引数を渡す関数でなければ、rdetoolkitは正しく処理が実行できません。
 
@@ -114,7 +114,7 @@ def dataset(srcpaths, resource_paths):
 - 各種入力ファイルのバリデーション
 
 !!! Reference
-    - API Documentation: [run - workflows](rdetoolkit/workflows.md/#run)
+    - API Documentation: [run - workflows](/rdetoolkit/workflows/#run)
 
 今回の例では、`main.py`を作成し、`modules/modules.py`で定義した`dataset()`を実行します。
 
@@ -165,7 +165,7 @@ python3 main.py
 
 ## 次のステップ
 
-- [カスタム構造化処理を実装する](structured_process/structured.md)
-- [RDEToolKitの設定ファイルと制御できる機能を知る](config/config.md)
-- [RDEのデータ登録モードを指定する](config/mode.md)
-- [テンプレートファイルを知る](metadata_definition_file.md)
+- [カスタム構造化処理を実装する](./structured_process/structured.md)
+- [RDEToolKitの設定ファイルと制御できる機能を知る](./config/config.md)
+- [RDEのデータ登録モードを指定する](./config/mode.md)
+- [テンプレートファイルを知る](./metadata_definition_file.md)

--- a/docs/usage/structured_process/errorhandling.md
+++ b/docs/usage/structured_process/errorhandling.md
@@ -22,7 +22,7 @@ ErrorMessage=ERROR: failed in data processing
 
 ## RDEToolKitを使ってエラーハンドリングを実装する
 
-RDEToolKitでは、[`rdetoolkit.workflows.run()`](rdetoolkit/workflows.md/#run)を利用することで、内部で発生した例外[`rdetoolkit.exceptions.StructuredError`](rdetoolkit/exceptions.md/#StructuredError)をキャッチすることが可能です。例えば、下記の例では、存在しないファイル読み込んだときのエラーを、job.failedに記述する例です。
+RDEToolKitでは、[`rdetoolkit.workflows.run()`](/rdetoolkit/workflows/#run)を利用することで、内部で発生した例外[`rdetoolkit.exceptions.StructuredError`](/rdetoolkit/exceptions/#StructuredError)をキャッチすることが可能です。例えば、下記の例では、存在しないファイル読み込んだときのエラーを、job.failedに記述する例です。
 
 ```python
 # main.py

--- a/docs/usage/structured_process/feature_description.md
+++ b/docs/usage/structured_process/feature_description.md
@@ -1,7 +1,7 @@
 # データタイル説明欄への自動記述について
 
 !!! Reference
-    - API Documentation: [update_description_with_features()](../../../rdetoolkit/invoicefile/#update_description_with_features)
+    - API Documentation: [update_description_with_features()](/rdetoolkit/invoicefile/#update_description_with_features)
 
 `data/tasksupport/metadata-def.json`に、`_feature`フィールドを定義することで、自動的に説明欄へ記述します。例えば、以下の例では、`length`と、`weight`に`_feature=true`が定義されているため、データタイルの説明欄へ自動的に記述されます。
 

--- a/docs/usage/structured_process/rdepath.md
+++ b/docs/usage/structured_process/rdepath.md
@@ -11,8 +11,8 @@ def dataset(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePath):
 ```
 
 !!! Reference
-    - API Documentation: [RdeInputDirPaths - rde2types](rdetoolkit/models/rde2types.md/#rdeinputdirpaths)
-    - API Documentation: [RdeOutputResourcePath - rde2types](rdetoolkit/models/rde2types.md/#rdeoutputresourcepath)
+    - API Documentation: [RdeInputDirPaths - rde2types](/rdetoolkit/models/rde2types/#rdeinputdirpaths)
+    - API Documentation: [RdeOutputResourcePath - rde2types](/rdetoolkit/models/rde2types/#rdeoutputresourcepath)
 
 `RdeInputDirPaths`は、入力で扱われるディレクトリパスやファイルパス群を格納してます。ディレクトリパスは、`pathlib.Path`オブジェクトで格納されています。
 

--- a/docs/usage/structured_process/structured.md
+++ b/docs/usage/structured_process/structured.md
@@ -24,7 +24,7 @@ graph LR
 起動処理では、カスタム構造化処理を実行する前の処理を実行します。
 
 !!! Reference
-    API Documents: [rdetoolkit.workflows.run](rdetoolkit/workflows.md/#run)
+    API Documents: [rdetoolkit.workflows.run](/rdetoolkit/workflows/#run)
 
 ### 実装例
 
@@ -92,8 +92,8 @@ def dataset(srcpaths: RdeInputDirPaths, resource_paths: RdeOutputResourcePath):
 - resource_paths (RdeOutputResourcePath): 処理結果を保存するための出力リソースパス情報
 
 !!! Reference
-    - API Documentation: [RdeInputDirPaths - rde2types](rdetoolkit/models/rde2types.md/#rdeinputdirpaths)
-    - API Documentation: [RdeOutputResourcePath - rde2types](rdetoolkit/models/rde2types.md/#rdeoutputresourcepath)
+    - API Documentation: [RdeInputDirPaths - rde2types](/rdetoolkit/models/rde2types/#rdeinputdirpaths)
+    - API Documentation: [RdeOutputResourcePath - rde2types](/rdetoolkit/models/rde2types/#rdeoutputresourcepath)
 
 今回の例では、`modules`以下に、`display_messsage()`, `custom_graph()`, `custom_extract_metadata()`というダミー処理を定義し、独自の構造化処理を定義します。これらの関数は、`modules/process.py`というファイルを作成し定義します。以下の2つの引数を渡す関数でなければ、rdetoolkitは正しく処理が実行できません。
 
@@ -160,4 +160,4 @@ graph TD
 
 以下のドキュメントを参照してください。
 
-- [データタイル説明欄への自動転記](feature_description.md)
+- [データタイル説明欄への自動転記](./feature_description.md)

--- a/docs/usage/validation.md
+++ b/docs/usage/validation.md
@@ -12,13 +12,13 @@ RDEToolKitでバリデーションの対象となるファイルは、以下の4
 - metadata.json
 
 !!! Tip "Documents"
-    - [テンプレートファイルについて](metadata_definition_file.md)
+    - [テンプレートファイルについて](./metadata_definition_file.md)
 
 ## invoice.schema.jsonのバリデーション
 
 `invoice.schema.json`をバリデーションする方法です。invoie.schema.jsonは、RDEの画面を構成するスキーマファイルですが、構造化処理中で変更、ローカルで定義ファイルを作成する点から、必要なフィールドが定義されているか確認するためのチェック機能を実行します。以下のバリデーション機能は、`rdetoolkit.workflows.run()`に組み込まれています。
 
-`invoice.schema.json`の各フィールドのチェックは、[`rdetoolkit.validation.InvoiceValidator`](../rdetoolkit/validation.md#invoicevalidator)で実行します。
+`invoice.schema.json`の各フィールドのチェックは、[`rdetoolkit.validation.InvoiceValidator`](/rdetoolkit/validation/#invoicevalidator)で実行します。
 
 ```python
 import json
@@ -134,7 +134,7 @@ schema = {
 ```
 
 !!! Tip
-    詳しい修正方法は、[invoice.schema.json - テンプレートファイルについて](metadata_definition_file.md/#invoiceschemajson_2) を参照ください。
+    詳しい修正方法は、[invoice.schema.json - テンプレートファイルについて](./metadata_definition_file.md/#invoiceschemajson_2) を参照ください。
 
 ## invoice.jsonのバリデーション
 
@@ -307,7 +307,7 @@ Context: '153cbe4798cb8c' does not match '^([0-9a-zA-Z]{56})$'
 ```
 
 !!! Tip
-    詳しい修正方法は、[invoice.json - テンプレートファイルについて](metadata_definition_file.md/#invoice.json_2) を参照ください。
+    詳しい修正方法は、[invoice.json - テンプレートファイルについて](./metadata_definition_file.md/#invoice.json_2) を参照ください。
 
 ## metadata.jsonのバリデーション
 
@@ -363,4 +363,4 @@ Error: Validation Errors in metadata.json. Please correct the following fields
 ```
 
 !!! Tip
-    詳しい修正方法は、[metadata.json - テンプレートファイルについて](metadata_definition_file.md/#metadatajson_1) を参照ください。
+    詳しい修正方法は、[metadata.json - テンプレートファイルについて](./metadata_definition_file.md/#metadatajson_1) を参照ください。

--- a/src/rdetoolkit/__init__.py
+++ b/src/rdetoolkit/__init__.py
@@ -5,4 +5,4 @@ from rdetoolkit.core import resize_image_aspect_ratio
 from . import exceptions, img2thumb, invoicefile, modeproc, rde2util, rdelogger, workflows
 from .impl import *
 from .interfaces import *
-from .models import *
+from .models import config, invoice_schema, metadata, rde2types

--- a/src/rdetoolkit/config.py
+++ b/src/rdetoolkit/config.py
@@ -5,35 +5,15 @@ from pathlib import Path
 from typing import Any, Final
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import ValidationError
 from tomlkit.toml_file import TOMLFile
 
+from rdetoolkit.models.config import Config
 from rdetoolkit.models.rde2types import RdeFsPath
 
 CONFIG_FILE: Final = ["rdeconfig.yaml", "rdeconfig.yml"]
 PYPROJECT_CONFIG_FILES: Final = ["pyproject.toml"]
 CONFIG_FILES = CONFIG_FILE + PYPROJECT_CONFIG_FILES
-
-
-class Config(BaseModel):
-    """The configuration class used in RDEToolKit.
-
-    Attributes:
-        extended_mode (Optional[str]): The mode to run the RDEToolKit in. It can be either 'rdeformat' or 'MultiDataTile'. If not specified, it defaults to None.
-        save_raw (bool): A boolean flag that indicates whether to automatically save raw data to the raw directory. It defaults to True.
-        save_thumbnail_image (bool): A boolean flag that indicates whether to automatically save the main image to the thumbnail directory. It defaults to False.
-        magic_variable (bool): A boolean flag that indicates whether to use the feature where specifying '${filename}' as the data name results in the filename being transcribed as the data name. It defaults to False.
-    """
-
-    model_config = ConfigDict(extra="allow")
-
-    extended_mode: str | None = Field(default=None, description="The mode to run the RDEtoolkit in. select: rdeformat, MultiDataTile")
-    save_raw: bool = Field(default=True, description="Auto Save raw data to the raw directory")
-    save_thumbnail_image: bool = Field(default=False, description="Auto Save main image to the thumbnail directory")
-    magic_variable: bool = Field(
-        default=False,
-        description="The feature where specifying '${filename}' as the data name results in the filename being transcribed as the data name.",
-    )
 
 
 def parse_config_file(*, path: str | None = None) -> Config:

--- a/src/rdetoolkit/config.pyi
+++ b/src/rdetoolkit/config.pyi
@@ -3,17 +3,11 @@ from pathlib import Path
 from pydantic import BaseModel
 from rdetoolkit.models.rde2types import RdeFsPath as RdeFsPath
 from typing import Final
+from models.config import Config
 
 CONFIG_FILE: Final[Incomplete]
 PYPROJECT_CONFIG_FILES: Final[Incomplete]
 CONFIG_FILES: Incomplete
-
-class Config(BaseModel):
-    model_config: Incomplete
-    extended_mode: str | None
-    save_raw: bool
-    save_thumbnail_image: bool
-    magic_variable: bool
 
 def parse_config_file(*, path: str | None = ...) -> Config: ...
 def is_toml(filename: str) -> bool: ...

--- a/src/rdetoolkit/img2thumb.py
+++ b/src/rdetoolkit/img2thumb.py
@@ -38,8 +38,8 @@ def __find_img_path(dirname: str, target_name: str) -> str:
 
 @catch_exception_with_message(error_message="ERROR: failed to copy image files", error_code=50)
 def copy_images_to_thumbnail(
-    out_dir_thumb_img: str,
-    out_dir_main_img: str,
+    out_dir_thumb_img: str | Path,
+    out_dir_main_img: str | Path,
     *,
     target_image_name: str | None = None,
     img_ext: str | None = None,
@@ -60,12 +60,12 @@ def copy_images_to_thumbnail(
     # When there are multiple images in the main image folder, copy one at the leading index as the representative image.
     __main_img_path: str = ""
     if target_image_name is not None:
-        __main_img_path = __find_img_path(out_dir_main_img, target_image_name)
+        __main_img_path = __find_img_path(str(out_dir_main_img), target_image_name)
     elif len(img_path_main) >= 1:
         __main_img_path = img_path_main[0]
 
     if __main_img_path:
-        __copy_img_to_thumb(out_dir_thumb_img, __main_img_path)
+        __copy_img_to_thumb(str(out_dir_thumb_img), __main_img_path)
 
 
 def resize_image(path: str | Path, width: int = 640, height: int = 480, output_path: str | Path | None = None) -> str:

--- a/src/rdetoolkit/img2thumb.pyi
+++ b/src/rdetoolkit/img2thumb.pyi
@@ -2,7 +2,7 @@ from pathlib import Path
 from rdetoolkit.exceptions import catch_exception_with_message as catch_exception_with_message
 
 
-def copy_images_to_thumbnail(out_dir_thumb_img: str, out_dir_main_img: str, *, target_image_name: str | None = ..., img_ext: str | None = ...) -> None:
+def copy_images_to_thumbnail(out_dir_thumb_img: str | Path, out_dir_main_img: str | Path, *, target_image_name: str | None = ..., img_ext: str | None = ...) -> None:
     pass
 
 

--- a/src/rdetoolkit/models/config.py
+++ b/src/rdetoolkit/models/config.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class Config(BaseModel, extra="allow"):
+    """The configuration class used in RDEToolKit.
+
+    Attributes:
+        extended_mode (Optional[str]): The mode to run the RDEToolKit in. It can be either 'rdeformat' or 'MultiDataTile'. If not specified, it defaults to None.
+        save_raw (bool): A boolean flag that indicates whether to automatically save raw data to the raw directory. It defaults to True.
+        save_thumbnail_image (bool): A boolean flag that indicates whether to automatically save the main image to the thumbnail directory. It defaults to False.
+        magic_variable (bool): A boolean flag that indicates whether to use the feature where specifying '${filename}' as the data name results in the filename being transcribed as the data name. It defaults to False.
+    """
+    extended_mode: str | None = Field(default=None, description="The mode to run the RDEtoolkit in. select: rdeformat, MultiDataTile")
+    save_raw: bool = Field(default=True, description="Auto Save raw data to the raw directory")
+    save_thumbnail_image: bool = Field(default=False, description="Auto Save main image to the thumbnail directory")
+    magic_variable: bool = Field(
+        default=False,
+        description="The feature where specifying '${filename}' as the data name results in the filename being transcribed as the data name.",
+    )

--- a/src/rdetoolkit/models/config.pyi
+++ b/src/rdetoolkit/models/config.pyi
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class Config(BaseModel, extra="allow"):
+    extended_mode: str | None
+    save_raw: bool
+    save_thumbnail_image: bool
+    magic_variable: bool

--- a/src/rdetoolkit/models/rde2types.py
+++ b/src/rdetoolkit/models/rde2types.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import warnings
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TypedDict, Union
 
@@ -103,6 +103,15 @@ class RdeFormatFlags:  # pragma: no cover
         self._is_multifile_enabled = value
 
 
+def create_default_config() -> Config:
+    """Creates and returns a default configuration object.
+
+    Returns:
+        Config: A default configuration object.
+    """
+    return Config(extended_mode=None, save_raw=True, save_thumbnail_image=False, magic_variable=False)
+
+
 @dataclass
 class RdeInputDirPaths:
     """A data class that holds folder paths used for input in the RDE.
@@ -123,7 +132,7 @@ class RdeInputDirPaths:
     inputdata: Path
     invoice: Path
     tasksupport: Path
-    config: Config = Config(extended_mode=None, save_raw=True, save_thumbnail_image=False, magic_variable=False)
+    config: Config = field(default_factory=create_default_config)
 
     @property
     def default_csv(self) -> Path:

--- a/src/rdetoolkit/models/rde2types.py
+++ b/src/rdetoolkit/models/rde2types.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TypedDict, Union
 
+from rdetoolkit.models.config import Config
+
 ZipFilesPathList = Sequence[Path]
 UnZipFilesPathList = Sequence[Path]
 ExcelInvoicePathList = Sequence[Path]
@@ -111,6 +113,7 @@ class RdeInputDirPaths:
         inputdata (Path): Path to the folder where input data is stored.
         invoice (Path): Path to the folder where invoice.json is stored.
         tasksupport (Path): Path to the folder where task support data is stored.
+        config (Config): The configuration object.
 
     Properties:
         default_csv (Path): Provides the path to the `default_value.csv` file. If `tasksupport` is specified, it uses the path under it; otherwise,
@@ -120,6 +123,7 @@ class RdeInputDirPaths:
     inputdata: Path
     invoice: Path
     tasksupport: Path
+    config: Config = Config(extended_mode=None, save_raw=True, save_thumbnail_image=False, magic_variable=False)
 
     @property
     def default_csv(self) -> Path:

--- a/src/rdetoolkit/models/rde2types.pyi
+++ b/src/rdetoolkit/models/rde2types.pyi
@@ -2,6 +2,8 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TypedDict, Union
 
+from rdetoolkit.models.config import Config
+
 ZipFilesPathList = Sequence[Path]
 UnZipFilesPathList = Sequence[Path]
 ExcelInvoicePathList = Sequence[Path]
@@ -26,6 +28,7 @@ class RdeInputDirPaths:
     inputdata: Path
     invoice: Path
     tasksupport: Path
+    config: Config
     @property
     def default_csv(self) -> Path: ...
     def __init__(self, inputdata, invoice, tasksupport) -> None: ...

--- a/src/rdetoolkit/modeproc.py
+++ b/src/rdetoolkit/modeproc.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Callable
 
 from rdetoolkit import img2thumb
-from rdetoolkit.config import Config
 from rdetoolkit.exceptions import StructuredError
 from rdetoolkit.impl.input_controller import (
     ExcelInvoiceChecker,
@@ -27,7 +26,6 @@ def rdeformat_mode_process(
     srcpaths: RdeInputDirPaths,
     resource_paths: RdeOutputResourcePath,
     datasets_process_function: _CallbackType | None = None,
-    config: Config | None = None,
 ) -> None:
     """Process the source data and apply specific transformations using the provided callback function.
 
@@ -53,8 +51,6 @@ def rdeformat_mode_process(
     Returns:
         None
     """
-    if config is None:
-        config = Config()
     # rewriting the invoice
     invoice_dst_filepath = resource_paths.invoice.joinpath("invoice.json")
     InvoiceFile.copy_original_invoice(resource_paths.invoice_org, invoice_dst_filepath)
@@ -64,7 +60,7 @@ def rdeformat_mode_process(
     if datasets_process_function is not None:
         datasets_process_function(srcpaths, resource_paths)
 
-    if config.save_thumbnail_image:
+    if srcpaths.config.save_thumbnail_image:
         img2thumb.copy_images_to_thumbnail(
             resource_paths.thumbnail,
             resource_paths.main_image,
@@ -86,7 +82,6 @@ def multifile_mode_process(
     srcpaths: RdeInputDirPaths,
     resource_paths: RdeOutputResourcePath,
     datasets_process_function: _CallbackType | None = None,
-    config: Config | None = None,
 ) -> None:
     """Processes multiple source files and applies transformations using the provided callback function.
 
@@ -113,13 +108,10 @@ def multifile_mode_process(
     Returns:
         None
     """
-    if config is None:
-        config = Config()
-
     invoice_dst_filepath = resource_paths.invoice.joinpath("invoice.json")
     InvoiceFile.copy_original_invoice(resource_paths.invoice_org, invoice_dst_filepath)
 
-    if config.save_raw:
+    if srcpaths.config.save_raw:
         copy_input_to_rawfile(resource_paths.raw, resource_paths.rawfiles)
 
     # run custom dataset process
@@ -127,10 +119,10 @@ def multifile_mode_process(
         datasets_process_function(srcpaths, resource_paths)
 
     # rewriting support for ${filename} by default
-    if config.magic_variable:
+    if srcpaths.config.magic_variable:
         apply_magic_variable(resource_paths.invoice.joinpath("invoice.json"), resource_paths.rawfiles[0])
 
-    if config.save_thumbnail_image:
+    if srcpaths.config.save_thumbnail_image:
         img2thumb.copy_images_to_thumbnail(resource_paths.thumbnail, resource_paths.main_image)
 
     with contextlib.suppress(Exception):
@@ -151,7 +143,6 @@ def excel_invoice_mode_process(
     excel_invoice_file: Path,
     idx: int,
     datasets_process_function: _CallbackType | None = None,
-    config: Config | None = None,
 ) -> None:
     """Processes invoice data from an Excel file and applies dataset transformations using the provided callback function.
 
@@ -181,9 +172,6 @@ def excel_invoice_mode_process(
     Returns:
         None
     """
-    if config is None:
-        config = Config()
-
     # rewriting the invoice
     excel_invoice = ExcelInvoiceFile(excel_invoice_file)
     try:
@@ -202,7 +190,7 @@ def excel_invoice_mode_process(
             eobj=e,
         ) from e
 
-    if config.save_raw:
+    if srcpaths.config.save_raw:
         copy_input_to_rawfile(resource_paths.raw, resource_paths.rawfiles)
 
     # run custom dataset process
@@ -212,10 +200,10 @@ def excel_invoice_mode_process(
     # rewriting support for ${filename} by default
     # Excelinvoice applies to file mode only, folder mode is not supported.
     # FileMode has only one element in resource_paths.rawfiles.
-    if config.magic_variable:
+    if srcpaths.config.magic_variable:
         apply_magic_variable(resource_paths.invoice.joinpath("invoice.json"), resource_paths.rawfiles[0])
 
-    if config.save_thumbnail_image:
+    if srcpaths.config.save_thumbnail_image:
         img2thumb.copy_images_to_thumbnail(resource_paths.thumbnail, resource_paths.main_image)
 
     with contextlib.suppress(Exception):
@@ -238,7 +226,6 @@ def invoice_mode_process(
     srcpaths: RdeInputDirPaths,
     resource_paths: RdeOutputResourcePath,
     datasets_process_function: _CallbackType | None = None,
-    config: Config | None = None,
 ) -> None:
     """Processes invoice-related data, applies dataset transformations using the provided callback function, and updates descriptions.
 
@@ -264,21 +251,18 @@ def invoice_mode_process(
     Returns:
         None
     """
-    if config is None:
-        config = Config()
-
-    if config.save_raw:
+    if srcpaths.config.save_raw:
         copy_input_to_rawfile(resource_paths.raw, resource_paths.rawfiles)
 
     # run custom dataset process
     if datasets_process_function is not None:
         datasets_process_function(srcpaths, resource_paths)
 
-    if config.save_thumbnail_image:
+    if srcpaths.config.save_thumbnail_image:
         img2thumb.copy_images_to_thumbnail(resource_paths.thumbnail, resource_paths.main_image)
 
     # rewriting support for ${filename} by default
-    if config.magic_variable:
+    if srcpaths.config.magic_variable:
         apply_magic_variable(resource_paths.invoice.joinpath("invoice.json"), resource_paths.rawfiles[0])
 
     with contextlib.suppress(Exception):

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -16,7 +16,7 @@ Note:
 
 from pathlib import Path
 
-from rdetoolkit.config import Config
+from rdetoolkit.models.config import Config
 from rdetoolkit.models.rde2types import RdeInputDirPaths
 from rdetoolkit.rde2util import StorageDir
 from rdetoolkit.workflows import check_files
@@ -34,6 +34,7 @@ def test_check_files_single(inputfile_single, ivnoice_json_none_sample_info, tas
         inputdata=StorageDir.get_specific_outputdir(False, "inputdata"),
         invoice=StorageDir.get_specific_outputdir(False, "invoice"),
         tasksupport=StorageDir.get_specific_outputdir(False, "tasksupport"),
+        config=format_flags,
     )
     raw_files_group, excel_invoice_files = check_files(srcpaths, mode=format_flags.extended_mode)
 
@@ -53,6 +54,7 @@ def test_check_files_multi(tasksupport, ivnoice_json_with_sample_info, inputfile
         inputdata=StorageDir.get_specific_outputdir(False, "inputdata"),
         invoice=StorageDir.get_specific_outputdir(False, "invoice"),
         tasksupport=StorageDir.get_specific_outputdir(False, "tasksupport"),
+        config=format_flags,
     )
     raw_files_group, excel_invoice_files = check_files(srcpaths, mode=format_flags.extended_mode)
 
@@ -73,6 +75,7 @@ def test_check_files_invoice_non_file(tasksupport, ivnoice_json_with_sample_info
         inputdata=StorageDir.get_specific_outputdir(False, "inputdata"),
         invoice=StorageDir.get_specific_outputdir(False, "invoice"),
         tasksupport=StorageDir.get_specific_outputdir(False, "tasksupport"),
+        config=format_flags,
     )
     raw_files_group, excel_invoice_files = check_files(srcpaths, mode=format_flags.extended_mode)
 
@@ -99,6 +102,7 @@ def test_check_files_excelinvoice_zip_with_file(
         inputdata=StorageDir.get_specific_outputdir(False, "inputdata"),
         invoice=StorageDir.get_specific_outputdir(False, "invoice"),
         tasksupport=StorageDir.get_specific_outputdir(False, "tasksupport"),
+        config=format_flags,
     )
     raw_files_group, excel_invoice_files = check_files(srcpaths, mode=format_flags.extended_mode)
 
@@ -126,6 +130,7 @@ def test_check_files_excelinvoice_zip_with_folder(
         inputdata=StorageDir.get_specific_outputdir(False, "inputdata"),
         invoice=StorageDir.get_specific_outputdir(False, "invoice"),
         tasksupport=StorageDir.get_specific_outputdir(False, "tasksupport"),
+        config=format_flags,
     )
     raw_files_group, excel_invoice_files = check_files(srcpaths, mode=format_flags.extended_mode)
 
@@ -143,6 +148,7 @@ def test_check_files_excelinvoice_non_file(tasksupport, ivnoice_json_with_sample
         inputdata=StorageDir.get_specific_outputdir(False, "inputdata"),
         invoice=StorageDir.get_specific_outputdir(False, "invoice"),
         tasksupport=StorageDir.get_specific_outputdir(False, "tasksupport"),
+        config=format_flags,
     )
     raw_files_group, excel_invoice_files = check_files(srcpaths, mode=format_flags.extended_mode)
 
@@ -176,6 +182,7 @@ def test_check_files_rdeformat_single(inputfile_rdeformat_divived, tasksupport, 
         inputdata=StorageDir.get_specific_outputdir(False, "inputdata"),
         invoice=StorageDir.get_specific_outputdir(False, "invoice"),
         tasksupport=StorageDir.get_specific_outputdir(False, "tasksupport"),
+        config=format_flags,
     )
     raw_files_group, excel_invoice_files = check_files(srcpaths, mode=format_flags.extended_mode)
 
@@ -201,6 +208,7 @@ def test_check_files_invoice_multiformat(tasksupport, ivnoice_json_with_sample_i
         inputdata=StorageDir.get_specific_outputdir(False, "inputdata"),
         invoice=StorageDir.get_specific_outputdir(False, "invoice"),
         tasksupport=StorageDir.get_specific_outputdir(False, "tasksupport"),
+        config=format_flags,
     )
     raw_files_group, excel_invoice_files = check_files(srcpaths, mode=format_flags.extended_mode)
     assert set(raw_files_group) == set(expect_rawfiles)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,8 @@ import shutil
 
 import pytest
 import yaml
-from rdetoolkit.config import Config, is_toml, is_yaml, parse_config_file, get_config, load_config
+from rdetoolkit.config import is_toml, is_yaml, parse_config_file, get_config, load_config
+from rdetoolkit.models.config import Config
 from tomlkit import document, table
 from tomlkit.toml_file import TOMLFile
 
@@ -200,6 +201,16 @@ def test_parse_config_file_current_project_pyprojecttoml(test_cwd_pyproject_toml
     assert config.save_raw is True
     assert config.save_thumbnail_image is True
     assert config.magic_variable is False
+
+
+def test_config_extra_allow():
+    config = Config(extended_mode="rdeformat", save_raw=True, save_thumbnail_image=False, magic_variable=False, extra_item="extra")
+    assert isinstance(config, Config)
+    assert config.extended_mode == "rdeformat"
+    assert config.save_raw is True
+    assert config.save_thumbnail_image is False
+    assert config.magic_variable is False
+    assert config.extra_item == "extra"
 
 
 def test_sucess_get_config_yaml(config_yaml):

--- a/tests/test_inputfile_checker.py
+++ b/tests/test_inputfile_checker.py
@@ -28,7 +28,7 @@ from rdetoolkit.impl.input_controller import (
 )
 from rdetoolkit.models.rde2types import RdeInputDirPaths
 from rdetoolkit.modeproc import selected_input_checker
-from rdetoolkit.config import Config
+from rdetoolkit.models.config import Config
 
 
 class TestInvoiceChecker:
@@ -223,35 +223,38 @@ class TestMultiFileChecker:
 
 
 def test_selected_input_checker_rde_format():
+    fmtflags = Config(extended_mode="rdeformat", save_raw=True, save_thumbnail_image=False)
     src_paths = RdeInputDirPaths(
         inputdata=Path("data/inputdata"),
         invoice=Path("data/invoice"),
         tasksupport=Path("data/tasksupport"),
+        config=fmtflags,
     )
     unpacked_dir_path = Path("data/temp")
-    fmtflags = Config(extended_mode="rdeformat", save_raw=True, save_thumbnail_image=False)
     assert isinstance(selected_input_checker(src_paths, unpacked_dir_path, fmtflags.extended_mode), RDEFormatChecker)
 
 
 def test_selected_input_checker_multi_file():
+    fmtflags = Config(extended_mode="MultiDataTile", save_raw=True, save_thumbnail_image=False)
     src_paths = RdeInputDirPaths(
         inputdata=Path("data/inputdata"),
         invoice=Path("data/invoice"),
         tasksupport=Path("data/tasksupport"),
+        config=fmtflags,
     )
     unpacked_dir_path = Path("data/temp")
-    fmtflags = Config(extended_mode="MultiDataTile", save_raw=True, save_thumbnail_image=False)
     assert isinstance(selected_input_checker(src_paths, unpacked_dir_path, fmtflags.extended_mode), MultiFileChecker)
 
 
 def test_selected_input_checker_excelinvoice(inputfile_zip_with_file, inputfile_single_excelinvoice):
+    fmtflags = Config(extended_mode=None, save_raw=True, save_thumbnail_image=False)
     src_paths = RdeInputDirPaths(
         inputdata=Path("data/inputdata"),
         invoice=Path("data/invoice"),
         tasksupport=Path("data/tasksupport"),
+        config=fmtflags,
     )
     unpacked_dir_path = Path("data/temp")
-    fmtflags = Config(extended_mode=None, save_raw=True, save_thumbnail_image=False)
     assert isinstance(
         selected_input_checker(src_paths, unpacked_dir_path, fmtflags.extended_mode),
         ExcelInvoiceChecker,
@@ -259,11 +262,12 @@ def test_selected_input_checker_excelinvoice(inputfile_zip_with_file, inputfile_
 
 
 def test_selected_input_checker_invoice(inputfile_single):
+    fmtflags = Config(extended_mode=None, save_raw=True, save_thumbnail_image=False)
     src_paths = RdeInputDirPaths(
         inputdata=Path("data/inputdata"),
         invoice=Path("data/invoice"),
         tasksupport=Path("data/tasksupport"),
+        config=fmtflags,
     )
     unpacked_dir_path = Path("data/temp")
-    fmtflags = Config(extended_mode=None, save_raw=True, save_thumbnail_image=False)
     assert isinstance(selected_input_checker(src_paths, unpacked_dir_path, fmtflags.extended_mode), InvoiceChecker)

--- a/tests/test_inputmode_processer.py
+++ b/tests/test_inputmode_processer.py
@@ -13,7 +13,7 @@ from rdetoolkit.modeproc import (
     multifile_mode_process,
     rdeformat_mode_process,
 )
-from rdetoolkit.config import Config
+from rdetoolkit.models.config import Config
 
 
 @pytest.fixture
@@ -142,10 +142,12 @@ def test_invoice_mode_process_calls_functions(
     expected_description = "desc1\n特徴量1:test-value1\n特徴量2(V):test-value2\n特徴量3(V):test-value3"
     mock_datasets_process_function = mocker.Mock()
 
+    config = Config(extended_mode=None, save_raw=True, magic_variable=False, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
     resource_paths = RdeOutputResourcePath(
         rawfiles=(
@@ -166,8 +168,7 @@ def test_invoice_mode_process_calls_functions(
     )
 
     # テスト対象の処理を実行
-    config = Config(extended_mode=None, save_raw=True, magic_variable=False, save_thumbnail_image=True)
-    invoice_mode_process(srcpaths, resource_paths, mock_datasets_process_function, config=config)
+    invoice_mode_process(srcpaths, resource_paths, mock_datasets_process_function)
 
     # 関数が呼び出されたかどうかをチェック
     mock_datasets_process_function.assert_called_once_with(srcpaths, resource_paths)
@@ -204,11 +205,14 @@ def test_invoice_mode_process_calls_functions_none_metadata_json(
     expected_description = "desc1"
     mock_datasets_process_function = mocker.Mock()
 
+    config = Config(extended_mode=None, save_raw=True, magic_variable=False, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
+
     resource_paths = RdeOutputResourcePath(
         rawfiles=(
             [
@@ -228,8 +232,7 @@ def test_invoice_mode_process_calls_functions_none_metadata_json(
     )
 
     # テスト対象の処理を実行
-    config = Config(extended_mode=None, save_raw=True, magic_variable=False, save_thumbnail_image=True)
-    invoice_mode_process(srcpaths, resource_paths, mock_datasets_process_function, config=config)
+    invoice_mode_process(srcpaths, resource_paths, mock_datasets_process_function)
 
     # 関数が呼び出されたかどうかをチェック
     mock_datasets_process_function.assert_called_once_with(srcpaths, resource_paths)
@@ -266,11 +269,14 @@ def test_invoice_mode_process_calls_functions_with_magic_variable(
     Path("data", "logs").mkdir(parents=True, exist_ok=True)
     mock_datasets_process_function = mocker.Mock()
 
+    config = Config(extended_mode=None, save_raw=True, magic_variable=True, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
+
     resource_paths = RdeOutputResourcePath(
         rawfiles=(
             [
@@ -290,8 +296,7 @@ def test_invoice_mode_process_calls_functions_with_magic_variable(
     )
 
     # テスト対象の処理を実行
-    config = Config(extended_mode=None, save_raw=True, magic_variable=True, save_thumbnail_image=True)
-    invoice_mode_process(srcpaths, resource_paths, mock_datasets_process_function, config=config)
+    invoice_mode_process(srcpaths, resource_paths, mock_datasets_process_function)
 
     # 関数が呼び出されたかどうかをチェック
     mock_datasets_process_function.assert_called_once_with(srcpaths, resource_paths)
@@ -336,11 +341,14 @@ def test_excel_invoice_mode_process_calls_functions(
     shutil.unpack_archive(Path("data", "inputdata", "test_input_multi.zip"), Path("data", "temp"))
     expected_description = "desc1\n特徴量1:test-value1\n特徴量2(V):test-value2\n特徴量3(V):test-value3"
 
+    config = Config(extended_mode=None, save_raw=True, magic_variable=True, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
+
     resource_paths = RdeOutputResourcePath(
         rawfiles=(
             [
@@ -358,13 +366,12 @@ def test_excel_invoice_mode_process_calls_functions(
         invoice_org=Path("data", "temp", "invoice_org.json"),
         invoice_schema_json=Path(ivnoice_schema_json_none_specificAttributes),
     )
-    config = Config(extended_mode=None, save_raw=True, magic_variable=True, save_thumbnail_image=True)
 
     # 関数のモック
     mock_datasets_process_function = mocker.Mock()
 
     # テスト対象の関数を実行
-    excel_invoice_mode_process(srcpaths, resource_paths, inputfile_single_dummy_header_excelinvoice, 0, mock_datasets_process_function, config=config)
+    excel_invoice_mode_process(srcpaths, resource_paths, inputfile_single_dummy_header_excelinvoice, 0, mock_datasets_process_function)
 
     # 関数が呼び出されたかどうかをチェック
     mock_datasets_process_function.assert_called_once_with(srcpaths, resource_paths)
@@ -414,11 +421,14 @@ def test_excel_invoice_mode_process_calls_functions_none_metadatajson(
     shutil.unpack_archive(Path("data", "inputdata", "test_input_multi.zip"), Path("data", "temp"))
     expected_description = "desc1"
 
+    config = Config(extended_mode=None, save_raw=True, magic_variable=True, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
+
     resource_paths = RdeOutputResourcePath(
         rawfiles=(
             [
@@ -436,13 +446,12 @@ def test_excel_invoice_mode_process_calls_functions_none_metadatajson(
         invoice_org=Path("data", "temp", "invoice_org.json"),
         invoice_schema_json=Path(ivnoice_schema_json_none_specificAttributes),
     )
-    config = Config(extended_mode=None, save_raw=True, magic_variable=True, save_thumbnail_image=True)
 
     # 関数のモック
     mock_datasets_process_function = mocker.Mock()
 
     # テスト対象の関数を実行
-    excel_invoice_mode_process(srcpaths, resource_paths, inputfile_single_dummy_header_excelinvoice, 0, mock_datasets_process_function, config=config)
+    excel_invoice_mode_process(srcpaths, resource_paths, inputfile_single_dummy_header_excelinvoice, 0, mock_datasets_process_function)
 
     # 関数が呼び出されたかどうかをチェック
     mock_datasets_process_function.assert_called_once_with(srcpaths, resource_paths)
@@ -491,11 +500,14 @@ def test_excel_invoice_mode_process_calls_functions_replace_magic_variable(
     )
     shutil.unpack_archive(Path("data", "inputdata", "test_input_multi.zip"), Path("data", "temp"))
 
+    config = Config(extended_mode=None, save_raw=True, magic_variable=True, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
+
     resource_paths = RdeOutputResourcePath(
         rawfiles=(
             [
@@ -517,9 +529,8 @@ def test_excel_invoice_mode_process_calls_functions_replace_magic_variable(
     mock_datasets_process_function = mocker.Mock()
 
     # テスト対象の関数を実行
-    config = Config(extended_mode=None, save_raw=True, magic_variable=True, save_thumbnail_image=True)
     excel_invoice_mode_process(
-        srcpaths, resource_paths, inputfile_single_dummy_header_excelinvoice_with_magic_variable, 0, mock_datasets_process_function, config=config
+        srcpaths, resource_paths, inputfile_single_dummy_header_excelinvoice_with_magic_variable, 0, mock_datasets_process_function
     )
 
     # 関数が呼び出されたかどうかをチェック
@@ -568,10 +579,12 @@ def test_multifile_mode_process_calls_functions(
     expected_description = "desc1\n特徴量1:test-value1\n特徴量2(V):test-value2\n特徴量3(V):test-value3"
     mock_datasets_process_function = mocker.Mock()
 
+    config = Config(extended_mode="MultiDataTile", save_raw=True, magic_variable=True, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
     resource_paths = RdeOutputResourcePath(
         rawfiles=(inputfile_multi),
@@ -588,8 +601,7 @@ def test_multifile_mode_process_calls_functions(
     )
 
     # テスト対象の処理を実行
-    config = Config(extended_mode="MultiDataTile", save_raw=True, magic_variable=True, save_thumbnail_image=True)
-    multifile_mode_process(srcpaths, resource_paths, mock_datasets_process_function, config=config)
+    multifile_mode_process(srcpaths, resource_paths, mock_datasets_process_function)
 
     # 関数が呼び出されたかどうかをチェック
     mock_datasets_process_function.assert_called_once_with(srcpaths, resource_paths)
@@ -642,11 +654,14 @@ def test_multifile_mode_process_calls_functions_none_metadata_json(
     expected_description = "desc1"
     mock_datasets_process_function = mocker.Mock()
 
+    config = Config(extended_mode="MultiDataTile", save_raw=True, magic_variable=True, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
+
     resource_paths = RdeOutputResourcePath(
         rawfiles=(inputfile_multi),
         raw=Path("data", "raw"),
@@ -662,8 +677,7 @@ def test_multifile_mode_process_calls_functions_none_metadata_json(
     )
 
     # テスト対象の処理を実行
-    config = Config(extended_mode="MultiDataTile", save_raw=True, magic_variable=True, save_thumbnail_image=True)
-    multifile_mode_process(srcpaths, resource_paths, mock_datasets_process_function, config=config)
+    multifile_mode_process(srcpaths, resource_paths, mock_datasets_process_function)
 
     # 関数が呼び出されたかどうかをチェック
     mock_datasets_process_function.assert_called_once_with(srcpaths, resource_paths)
@@ -717,10 +731,12 @@ def test_multifile_mode_process_calls_functions_replace_magic_filename(
         Path("data", "temp", "invoice_org.json"),
     )
 
+    config = Config(extended_mode="MultiDataTile", save_raw=True, magic_variable=True, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
     resource_paths1 = RdeOutputResourcePath(
         rawfiles=(inputfile_multi[0],),
@@ -779,8 +795,7 @@ def test_multifile_mode_process_calls_functions_replace_magic_filename(
             expected_filename = expected_filename2
             invoice = Path("data", "divided", f"{1:04d}", "invoice", "invoice.json")
 
-        config = Config(extended_mode="MultiDataTile", save_raw=True, magic_variable=True, save_thumbnail_image=True)
-        multifile_mode_process(srcpaths, resource_paths, mock_datasets_process_function, config=config)
+        multifile_mode_process(srcpaths, resource_paths, mock_datasets_process_function)
 
         # 関数が呼び出されたかどうかをチェック
         mock_datasets_process_function.assert_called_with(srcpaths, resource_paths)
@@ -840,10 +855,13 @@ def test_rdeformat_mode_process_alls_functions(
     mock_datasets_process_function = mocker.Mock()
 
     raw_files = tuple(f for f in Path("data", "temp").rglob("*") if f.is_file())
+
+    config = Config(extended_mode="rdeformat", save_raw=True, magic_variable=False, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
     resource_paths = RdeOutputResourcePath(
         rawfiles=raw_files,
@@ -858,9 +876,8 @@ def test_rdeformat_mode_process_alls_functions(
         invoice_org=Path("data", "temp", "invoice_org.json"),
         invoice_schema_json=invoice_shcema_json_full,
     )
-    config = Config(extended_mode="rdeformat", save_raw=True, magic_variable=False, save_thumbnail_image=True)
     # テスト対象の処理を実行
-    rdeformat_mode_process(srcpaths, resource_paths, mock_datasets_process_function, config=config)
+    rdeformat_mode_process(srcpaths, resource_paths, mock_datasets_process_function)
 
     # 関数が呼び出されたかどうかをチェック
     mock_datasets_process_function.assert_called_once_with(srcpaths, resource_paths)
@@ -913,10 +930,12 @@ def test_rdeformat_mode_process_alls_functions_none_metadata_json(
     mock_datasets_process_function = mocker.Mock()
 
     raw_files = tuple(f for f in Path("data", "temp").rglob("*") if f.is_file())
+    config = Config(extended_mode="rdeformat", save_raw=True, magic_variable=False, save_thumbnail_image=True)
     srcpaths = RdeInputDirPaths(
         inputdata=Path("data", "inputdata"),
         invoice=Path("data", "invoice"),
         tasksupport=Path("data", "tasksupport"),
+        config=config,
     )
     resource_paths = RdeOutputResourcePath(
         rawfiles=raw_files,
@@ -931,9 +950,8 @@ def test_rdeformat_mode_process_alls_functions_none_metadata_json(
         invoice_org=Path("data", "temp", "invoice_org.json"),
         invoice_schema_json=invoice_shcema_json_full,
     )
-    config = Config(extended_mode="rdeformat", save_raw=True, magic_variable=False, save_thumbnail_image=True)
     # テスト対象の処理を実行
-    rdeformat_mode_process(srcpaths, resource_paths, mock_datasets_process_function, config=config)
+    rdeformat_mode_process(srcpaths, resource_paths, mock_datasets_process_function)
 
     # 関数が呼び出されたかどうかをチェック
     mock_datasets_process_function.assert_called_once_with(srcpaths, resource_paths)

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -7,7 +7,7 @@ import yaml
 import toml
 
 from rdetoolkit.workflows import run
-from rdetoolkit.config import Config
+from rdetoolkit.models.config import Config
 
 
 @pytest.fixture


### PR DESCRIPTION
## issue
<!--関連issueを記載する-->
#41: rdeconfigを参照できる機能

## 変更内容
<!--対応内容や変更内容を記載する-->
- #41: rdeconfigをカスタム構造化処理内から受け取れるように変更
  - RdeInputDirPaths.configからtasksupportの設定ファイルのオブジェクトを参照可能になった。


## 実施していない内容
<!--今回の変更で対応しない・できない内容を記載する-->

## 検証内容
<!--プルリクで確認する内容を列挙する-->

- [ ] CIのテストがパスする
- [ ] 対象のスクリプトの変更に問題がないか
  - `src/rdetoolkit/models/rde2types.py`
  - `src/rdetoolkit/models/config.py`
  - `src/rdetoolkit/config.py`
  - `src/rdetoolkit/workflows.py`
