### PR TITLE
Develop/48 生データ格納先をデフォルトでnonshared_rawに変更する

### DIFF
--- a/docs/usage/config/config.md
+++ b/docs/usage/config/config.md
@@ -36,13 +36,15 @@ rdetoolkitでは、4つの起動モードをサポートしています。
 === "マルチデータタイル"
 
     ```yaml
-    extended_mode: 'MultiDataTile'
+    system:
+        extended_mode: 'MultiDataTile'
     ```
 
 === "RDEフォーマットモード"
 
     ```yaml
-    extended_mode: 'rdeformat'
+    system:
+        extended_mode: 'rdeformat'
     ```
 
 #### 起動条件
@@ -56,18 +58,39 @@ rdetoolkitでは、4つの起動モードをサポートしています。
 
 ### 入力ファイルの自動保存
 
-入力ファイルの自動保存は、`true`にすると、登録したファイルを自動的に、`raw`フォルダへ格納します。`false`にすると、登録したデータの操作はされないため、ユーザー自身でファイル操作する必要があります。
+入力ファイルの自動保存を有効化すると、自動的に`raw`ディレクトリもしくは、`nonshared_raw`ディレクトリに入力ファイルを保存します。保存先は、RDEデータセット公開と共にデータが共有される`raw`, RDEデータセットが公開されても入力ファイルが共有されない`nonshared_raw`があり、利用状況に応じて設定ファイルより設定してください。
 
-=== "入力データの自動保存の有効化"
+| 設定値             | 値               | 説明                                                           |
+| ------------------ | ---------------- | -------------------------------------------------------------- |
+| save_raw           | `true` / `false` | `raw`ディレクトリに保存する。デフォルトは`false`               |
+| save_nonshared_raw | `true` / `false` | `save_nonshared_raw`ディレクトリに保存する。デフォルトは`true` |
+
+=== "入力データの自動保存の有効化(raw)"
 
     ```yaml
-    save_raw: true
+    system:
+        save_raw: true
     ```
 
-=== "入力データの自動保存の無効化"
+=== "入力データの自動保存の無効化(raw)"
 
     ```yaml
-    save_raw: false
+    system:
+        save_raw: false
+    ```
+
+=== "入力データの自動保存の有効化(nonshared_raw)"
+
+    ```yaml
+    system:
+        save_nonshared_raw: true
+    ```
+
+=== "入力データの自動保存の無効化(nonshared_raw)"
+
+    ```yaml
+    system:
+        save_nonshared_raw: false
     ```
 
 ### magic variable
@@ -80,13 +103,15 @@ rdetoolkitでは、4つの起動モードをサポートしています。
 === "magic variableの有効化"
 
     ```yaml
-    magic_variable: true
+    system:
+        magic_variable: true
     ```
 
 === "magic variableの無効化"
 
     ```yaml
-    magic_variable: false
+    system:
+        magic_variable: false
     ```
 
 ### サムネイル画像の自動保存
@@ -96,21 +121,53 @@ rdetoolkitでは、4つの起動モードをサポートしています。
 === "サムネイル画像の自動保存の有効化"
 
     ```yaml
-    save_thumbnail_image: ture
+    system:
+        save_thumbnail_image: ture
     ```
 
 === "サムネイル画像の自動保存の無効化"
 
     ```yaml
-    save_thumbnail_image: false
+    system:
+        save_thumbnail_image: false
     ```
 
 ### 独自の設定値を設定する
 
 `rdeconfig.yaml`等の設定ファイルは、ユーザー独自の設定値を記述することができます。例えば、サムネイルの画像にどのファイルにするか指定する場合、`thumbnail_image_name`という設定値を以下のように記述します。
 
+=== "yml・yaml"
+
     ```yaml
-    thumbnail_image_name: "inputdata/sample_image.png"
+    custom:
+        thumbnail_image_name: "inputdata/sample_image.png"
+    ```
+
+=== "pyproject.toml"
+
+    ```toml
+    [tool.rdetoolkit.custom]
+     thumbnail_image_name: "inputdata/sample_image.png"
+    ```
+
+> 設定値の書き方については、YAMLフォーマットに従って記述してください。: [YAML Ain’t Markup Language (YAML™) version 1.2](https://yaml.org/spec/1.2.2/)
+
+### MultiDataTileモードでエラーによるプログラム終了をスキップする
+
+`MultiDataTile`は、一度に複数のデータを登録できますが、途中でエラーが発生すると、処理が停止し、最後まで構造化処理が実行されません。このとき、入力したファイルに対して処理を最後まで実行したい場合、`multidata_tile`というセクションの`ignore_errors`を有効化してください。デフォルトは、`false`となっており、エラーが発生すると処理が終了します。
+
+=== "エラー処理スキップ機能を有効化"
+
+    ```yaml
+    multidata_tile:
+        ignore_errors: true
+    ```
+
+=== "エラー処理スキップ機能を無効化"
+
+    ```yaml
+    multidata_tile:
+        ignore_errors: false
     ```
 
 > 設定値の書き方については、YAMLフォーマットに従って記述してください。: [YAML Ain’t Markup Language (YAML™) version 1.2](https://yaml.org/spec/1.2.2/)
@@ -120,18 +177,21 @@ rdetoolkitでは、4つの起動モードをサポートしています。
 === "rdeconfig.yml"
 
     ```yaml
-    extended_mode: 'MultiDataTile'
-    save_raw: true
-    magic_variable: false
-    save_thumbnail_image: true
+    system:
+        extended_mode: 'MultiDataTile'
+        save_raw: false
+        save_nonshared_raw: true
+        magic_variable: false
+        save_thumbnail_image: true
     ```
 
 === "pyproject.toml"
 
     ```toml
-    [tool.rdetoolkit]
+    [tool.rdetoolkit.system]
     extended_mode = 'MultiDataTile'
     save_raw = true
+    save_nonshared_raw=true
     magic_variable = false
     save_thumbnail_image = true
     ```
@@ -146,17 +206,17 @@ rdetoolkitでは、4つの起動モードをサポートしています。
         ... #任意の処理
 
         # Extendeds Modeの設定値を取得する
-        print(srcpaths.config.extended_mode)
+        print(srcpaths.config.system.extended_mode)
 
         # 入力ファイルの自動保存の設定値を取得する
-        print(srcpaths.config.save_raw)
+        print(srcpaths.config.system.save_raw)
 
         # サムネイル画像の自動保存の設定値を参照する
-        print(srcpaths.config.save_thumbnail_image)
+        print(srcpaths.config.system.save_thumbnail_image)
 
         # magic variableの設定値を参照する
-        print(srcpaths.config.magic_variable)
+        print(srcpaths.config.system.magic_variable)
 
-        # 独自に定義した設定値を参照する場合: thumbnail_image_name
-        print(srcpaths.config.magic_variable)
+        # 独自の設定値を参照する
+        print(srcpaths.config.custom.thumbnail_image_name)
     ```

--- a/docs/usage/structured_process/structured.md
+++ b/docs/usage/structured_process/structured.md
@@ -124,7 +124,65 @@ from modules import process #独自で定義した構造化処理関数
 import rdetoolkit
 
 # run()にカスタム構造化処理をを渡す
-rdetoolkit.workflows.run(custom_dataset_function=process.dataset)
+result = rdetoolkit.workflows.run(custom_dataset_function=process.dataset)
+```
+
+`result`には、構造化処理の実行ステータスが格納されます。
+
+```shell
+{
+  "statuses": [
+    {
+      "run_id": "0000",
+      "title": "test-dataset",
+      "status": "success",
+      "mode": "MultiDataTile",
+      "error_code": null,
+      "error_message": null,
+      "target": "data/inputdata",
+      "stacktrace": null
+    },
+    {
+      "run_id": "0001",
+      "title": "test-dataset",
+      "status": "success",
+      "mode": "MultiDataTile",
+      "error_code": null,
+      "error_message": null,
+      "target": "data/inputdata",
+      "stacktrace": null
+    }
+  ]
+}
+```
+
+失敗した時の`result`の出力
+
+```shell
+{
+  "statuses": [
+    {
+      "run_id": "0000",
+      "title": "Structured Process Faild: MultiDataTile",
+      "status": "failed",
+      "mode": "MultiDataTile",
+      "error_code": 999,
+      "error_message": "Error: Error in modules",
+      "target": "data/inputdata/sample1.txt",
+      "stacktrace": "Traceback (most recent call last):\n  File \"/Users/myproject/.venv/lib/python3.10/site-packages/rdetoolkit/exceptions.py\", line 158, in skip_exception_context\n    yield error_info\n  File \"/Users/myproject/.venv/lib/python3.10/site-packages/rdetoolkit/workflows.py\", line 242, in run\n    status = multifile_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)\n  File \"/Users/myproject/.venv/lib/python3.10/site-packages/rdetoolkit/modeproc.py\", line 157, in multifile_mode_process\n    datasets_process_function(srcpaths, resource_paths)\n  File \"/Users/myproject/modules/modules.py\", line 5, in error_modules\n    raise Exception(\"Error in modules\")\nException: Error in modules\n"
+    },
+    {
+      "run_id": "0001",
+      "title": "Structured Process Faild: MultiDataTile",
+      "status": "failed",
+      "mode": "MultiDataTile",
+      "error_code": 999,
+      "error_message": "Error: Error in modules",
+      "target": "data/inputdata/sample2.txt",
+      "stacktrace": "Traceback (most recent call last):\n  File \"/Users/myproject/.venv/lib/python3.10/site-packages/rdetoolkit/exceptions.py\", line 158, in skip_exception_context\n    yield error_info\n  File \"/Users/myproject/.venv/lib/python3.10/site-packages/rdetoolkit/workflows.py\", line 242, in run\n    status = multifile_mode_process(str(idx), srcpaths, rdeoutput_resource, custom_dataset_function)\n  File \"/Users/myproject/.venv/lib/python3.10/site-packages/rdetoolkit/modeproc.py\", line 157, in multifile_mode_process\n    datasets_process_function(srcpaths, resource_paths)\n  File \"/Users/myproject/modules/modules.py\", line 5, in error_modules\n    raise Exception(\"Error in modules\")\nException: Error in modules\n"
+    }
+  ]
+}
 ```
 
 ## 終了処理について

--- a/src/rdetoolkit/models/config.py
+++ b/src/rdetoolkit/models/config.py
@@ -8,13 +8,15 @@ class SystemSettings(BaseModel):
 
     Attributes:
         extended_mode (str | None): The mode to run the RDEtoolkit in. Options include 'rdeformat' and 'MultiDataTile'. Default is None.
-        save_raw (bool): Indicates whether to automatically save raw data to the raw directory. Default is True.
+        save_raw (bool): Indicates whether to automatically save raw data to the raw directory. Default is False.
+        save_nonshared_raw (bool): Indicates whether to save nonshared raw data. If True, non-shared raw data will be saved. Default is True.
         save_thumbnail_image (bool): Indicates whether to automatically save the main image to the thumbnail directory. Default is False.
         magic_variable (bool): A feature where specifying '${filename}' as the data name results in the filename being transcribed as the data name. Default is False.
     """
 
     extended_mode: str | None = Field(default=None, description="The mode to run the RDEtoolkit in. select: rdeformat, MultiDataTile")
-    save_raw: bool = Field(default=True, description="Auto Save raw data to the raw directory")
+    save_raw: bool = Field(default=False, description="Auto Save raw data to the raw directory")
+    save_nonshared_raw: bool = Field(default=True, description="Specifies whether to save nonshared raw data. If True, non-shared raw data will be saved.")
     save_thumbnail_image: bool = Field(default=False, description="Auto Save main image to the thumbnail directory")
     magic_variable: bool = Field(
         default=False,

--- a/src/rdetoolkit/models/config.pyi
+++ b/src/rdetoolkit/models/config.pyi
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 class SystemSettings(BaseModel):
     extended_mode: str | None
     save_raw: bool
+    save_nonshared_raw: bool
     save_thumbnail_image: bool
     magic_variable: bool
 
@@ -11,4 +12,4 @@ class MultiDataTileSettings(BaseModel):
 
 class Config(BaseModel, extra='allow'):
     system: SystemSettings
-    multidata_tile: MultiDataTileSettings
+    multidata_tile: MultiDataTileSettings | None

--- a/src/rdetoolkit/models/rde2types.py
+++ b/src/rdetoolkit/models/rde2types.py
@@ -156,6 +156,7 @@ class RdeOutputResourcePath:
 
     Attributes:
         raw (Path): Path where raw data is stored.
+        nonshared_raw (Path): Path where nonshared raw data is stored.
         rawfiles (tuple[Path, ...]): Holds a tuple of input file paths, such as those unzipped, for a single tile of data.
         struct (Path): Path for storing structured data.
         main_image (Path): Path for storing the main image file.
@@ -172,6 +173,7 @@ class RdeOutputResourcePath:
     """
 
     raw: Path
+    nonshared_raw: Path
     rawfiles: tuple[Path, ...]
     struct: Path
     main_image: Path
@@ -185,7 +187,6 @@ class RdeOutputResourcePath:
     temp: Path | None = None
     invoice_patch: Path | None = None
     attachment: Path | None = None
-    nonshared_raw: Path | None = None
 
 
 class Name(TypedDict):

--- a/src/rdetoolkit/models/rde2types.pyi
+++ b/src/rdetoolkit/models/rde2types.pyi
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from rdetoolkit.models.config import Config as Config
+from rdetoolkit.models.config import Config as Config, MultiDataTileSettings as MultiDataTileSettings, SystemSettings as SystemSettings
 from typing import TypedDict
 
 ZipFilesPathList = Sequence[Path]
@@ -44,6 +44,7 @@ class RdeInputDirPaths:
 @dataclass
 class RdeOutputResourcePath:
     raw: Path
+    nonshared_raw: Path
     rawfiles: tuple[Path, ...]
     struct: Path
     main_image: Path
@@ -57,8 +58,7 @@ class RdeOutputResourcePath:
     temp: Path | None = ...
     invoice_patch: Path | None = ...
     attachment: Path | None = ...
-    nonshared_raw: Path | None = ...
-    def __init__(self, raw, rawfiles, struct, main_image, other_image, meta, thumbnail, logs, invoice, invoice_schema_json, invoice_org, temp=..., invoice_patch=..., attachment=..., nonshared_raw=...) -> None: ...
+    def __init__(self, raw, nonshared_raw, rawfiles, struct, main_image, other_image, meta, thumbnail, logs, invoice, invoice_schema_json, invoice_org, temp=..., invoice_patch=..., attachment=...) -> None: ...
 
 class Name(TypedDict):
     ja: str

--- a/src/rdetoolkit/modeproc.py
+++ b/src/rdetoolkit/modeproc.py
@@ -102,6 +102,7 @@ def rdeformat_mode_process(
         error_code=None,
         error_message=None,
         target=str(basedir),
+        stacktrace=None,
     )
 
 
@@ -152,6 +153,9 @@ def multifile_mode_process(
     if srcpaths.config.system.save_raw:
         copy_input_to_rawfile(resource_paths.raw, resource_paths.rawfiles)
 
+    if srcpaths.config.system.save_nonshared_raw:
+        copy_input_to_rawfile(resource_paths.nonshared_raw, resource_paths.rawfiles)
+
     # run custom dataset process
     if datasets_process_function is not None:
         datasets_process_function(srcpaths, resource_paths)
@@ -182,6 +186,7 @@ def multifile_mode_process(
         error_code=None,
         error_message=None,
         target=str(basedir),
+        stacktrace=None,
     )
 
 
@@ -248,6 +253,9 @@ def excel_invoice_mode_process(
     if srcpaths.config.system.save_raw:
         copy_input_to_rawfile(resource_paths.raw, resource_paths.rawfiles)
 
+    if srcpaths.config.system.save_nonshared_raw:
+        copy_input_to_rawfile(resource_paths.nonshared_raw, resource_paths.rawfiles)
+
     # run custom dataset process
     if datasets_process_function is not None:
         datasets_process_function(srcpaths, resource_paths)
@@ -286,6 +294,7 @@ def excel_invoice_mode_process(
         error_code=None,
         error_message=None,
         target=str(basedir),
+        stacktrace=None,
     )
 
 
@@ -330,6 +339,9 @@ def invoice_mode_process(
     if srcpaths.config.system.save_raw:
         copy_input_to_rawfile(resource_paths.raw, resource_paths.rawfiles)
 
+    if srcpaths.config.system.save_nonshared_raw:
+        copy_input_to_rawfile(resource_paths.nonshared_raw, resource_paths.rawfiles)
+
     # run custom dataset process
     if datasets_process_function is not None:
         datasets_process_function(srcpaths, resource_paths)
@@ -366,6 +378,7 @@ def invoice_mode_process(
         error_code=None,
         error_message=None,
         target=str(basedir),
+        stacktrace=None,
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,7 +26,7 @@ def test_is_yaml():
 
 @pytest.fixture()
 def config_yaml():
-    system_data = {"extended_mode": "rdeformat", "save_raw": True, "magic_variable": False, "save_thumbnail_image": True}
+    system_data = {"extended_mode": "rdeformat", "save_raw": True, "save_nonshared_raw": False, "magic_variable": False, "save_thumbnail_image": True}
     multi_data = {"ignore_errors": False}
     data = {"system": system_data, "multidata_tile": multi_data}
     test_yaml_path = "rdeconfig.yaml"
@@ -43,7 +43,7 @@ def config_yaml():
 def config_yml():
     dirname = Path("tasksupport")
     dirname.mkdir(exist_ok=True)
-    system_data = {"extended_mode": "rdeformat", "save_raw": True, "magic_variable": False, "save_thumbnail_image": True}
+    system_data = {"extended_mode": "rdeformat", "save_raw": True, "save_nonshared_raw": False, "magic_variable": False, "save_thumbnail_image": True}
     multi_data = {"ignore_errors": False}
     data = {"system": system_data, "multidata_tile": multi_data}
     test_yaml_path = dirname.joinpath("rdeconfig.yml")
@@ -62,7 +62,7 @@ def config_yml():
 def config_yml_none_multiconfig():
     dirname = Path("tasksupport")
     dirname.mkdir(exist_ok=True)
-    system_data = {"extended_mode": "rdeformat", "save_raw": True, "magic_variable": False, "save_thumbnail_image": True}
+    system_data = {"extended_mode": "rdeformat", "save_raw": True, "save_nonshared_raw": False, "magic_variable": False, "save_thumbnail_image": True}
     data = {"system": system_data}
     test_yaml_path = dirname.joinpath("rdeconfig.yml")
     with open(test_yaml_path, mode="w", encoding="utf-8") as f:
@@ -80,7 +80,7 @@ def config_yml_none_multiconfig():
 def invalid_config_yaml():
     dirname = Path("tasksupport")
     dirname.mkdir(exist_ok=True)
-    system_data = {"extended_mode": "rdeformat", "save_raw": True, "magic_variable": False, "save_thumbnail_image": True}
+    system_data = {"extended_mode": "rdeformat", "save_raw": True, "save_nonshared_raw": False, "magic_variable": False, "save_thumbnail_image": True}
     multi_data = {"ignore_errors": False}
     data = {"system": system_data, "multidata_tile": multi_data}
     test_yaml_path = dirname.joinpath("invalid_rdeconfig.yaml")
@@ -99,7 +99,7 @@ def invalid_config_yaml():
 def invalid_field_config_yaml():
     dirname = Path("tasksupport")
     dirname.mkdir(exist_ok=True)
-    system_data = {"extended_mode": 123, "save_raw": 1, "magic_variable": False, "save_thumbnail_image": True}
+    system_data = {"extended_mode": 123, "save_raw": 1, "save_nonshared_raw": False, "magic_variable": False, "save_thumbnail_image": True}
     multi_data = {"ignore_errors": False}
     data = {"system": system_data, "multidata_tile": multi_data}
     test_yaml_path = dirname.joinpath("invalid_rdeconfig.yaml")
@@ -140,6 +140,7 @@ def test_pyproject_toml():
     doc["tool"]["rdetoolkit"]["multidata_tile"] = table()
     doc["tool"]["rdetoolkit"]["system"]["extended_mode"] = "rdeformat"
     doc["tool"]["rdetoolkit"]["system"]["save_raw"] = True
+    doc["tool"]["rdetoolkit"]["system"]["save_nonshared_raw"] = False
     doc["tool"]["rdetoolkit"]["system"]["magic_variable"] = False
     doc["tool"]["rdetoolkit"]["system"]["save_thumbnail_image"] = True
     doc["tool"]["rdetoolkit"]["multidata_tile"]["ignore_errors"] = False
@@ -164,6 +165,7 @@ def test_cwd_pyproject_toml():
     doc["tool"]["rdetoolkit"]["multidata_tile"] = table()
     doc["tool"]["rdetoolkit"]["system"]["extended_mode"] = "MultiDataTile"
     doc["tool"]["rdetoolkit"]["system"]["save_raw"] = True
+    doc["tool"]["rdetoolkit"]["system"]["save_nonshared_raw"] = False
     doc["tool"]["rdetoolkit"]["system"]["magic_variable"] = False
     doc["tool"]["rdetoolkit"]["system"]["save_thumbnail_image"] = True
     doc["tool"]["rdetoolkit"]["multidata_tile"]["ignore_errors"] = False
@@ -202,6 +204,7 @@ def test_parse_config_file(config_yaml):
     assert isinstance(config, Config)
     assert config.system.extended_mode == "rdeformat"
     assert config.system.save_raw is True
+    assert config.system.save_nonshared_raw is False
     assert config.system.save_thumbnail_image is True
     assert config.system.magic_variable is False
     assert config.multidata_tile.ignore_errors is False
@@ -212,6 +215,7 @@ def test_parse_config_file_specificaton_pyprojecttoml(test_pyproject_toml):
     assert isinstance(config, Config)
     assert config.system.extended_mode == "rdeformat"
     assert config.system.save_raw is True
+    assert config.system.save_nonshared_raw is False
     assert config.system.save_thumbnail_image is True
     assert config.system.magic_variable is False
     assert config.multidata_tile.ignore_errors is False
@@ -228,19 +232,20 @@ def test_parse_config_file_current_project_pyprojecttoml(test_cwd_pyproject_toml
 
 
 def test_config_extra_allow():
-    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_thumbnail_image=False, magic_variable=False)
+    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_nonshared_raw=False, save_thumbnail_image=False, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     config = Config(system=system, multidata_tile=multi, extra_item="extra")
     assert isinstance(config, Config)
     assert config.system.extended_mode == "rdeformat"
     assert config.system.save_raw is True
+    assert config.system.save_nonshared_raw is False
     assert config.system.save_thumbnail_image is False
     assert config.system.magic_variable is False
     assert config.extra_item == "extra"
 
 
 def test_sucess_get_config_yaml(config_yaml):
-    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_thumbnail_image=True, magic_variable=False)
+    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_nonshared_raw=False, save_thumbnail_image=True, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     expected_text = Config(system=system, multidata_tile=multi)
     valid_dir = Path.cwd()
@@ -250,7 +255,7 @@ def test_sucess_get_config_yaml(config_yaml):
 
 def test_sucess_get_config_yaml_none_multitile_setting(config_yml_none_multiconfig):
     # 入力ではmultidata_tileはNoneだが、デフォルト値が格納されることをテスト
-    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_thumbnail_image=True, magic_variable=False)
+    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_nonshared_raw=False, save_thumbnail_image=True, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     expected_text = Config(system=system, multidata_tile=multi)
     valid_dir = Path("tasksupport")
@@ -259,7 +264,7 @@ def test_sucess_get_config_yaml_none_multitile_setting(config_yml_none_multiconf
 
 
 def test_sucess_get_config_yml(config_yml):
-    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_thumbnail_image=True, magic_variable=False)
+    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_nonshared_raw=False, save_thumbnail_image=True, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     expected_text = Config(system=system, multidata_tile=multi)
     valid_dir = Path("tasksupport")
@@ -269,7 +274,7 @@ def test_sucess_get_config_yml(config_yml):
 
 def test_invalid_get_config_yml(invalid_config_yaml):
     valid_dir = Path("tasksupport")
-    system = SystemSettings(extended_mode=None, save_raw=True, save_thumbnail_image=False, magic_variable=False)
+    system = SystemSettings(extended_mode=None, save_raw=False, save_nonshared_raw=True, save_thumbnail_image=False, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     expected_text = Config(system=system, multidata_tile=multi)
     config = get_config(valid_dir)
@@ -277,7 +282,7 @@ def test_invalid_get_config_yml(invalid_config_yaml):
 
 
 def test_get_config_pyprojecttoml(test_cwd_pyproject_toml):
-    system = SystemSettings(extended_mode="MultiDataTile", save_raw=True, save_thumbnail_image=True, magic_variable=False)
+    system = SystemSettings(extended_mode="MultiDataTile", save_raw=True, save_nonshared_raw=False, save_thumbnail_image=True, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     expected_text = Config(system=system, multidata_tile=multi)
     valid_dir = Path.cwd()
@@ -286,7 +291,7 @@ def test_get_config_pyprojecttoml(test_cwd_pyproject_toml):
 
 
 def test_invalid_get_config_empty_yml(invalid_empty_config_yaml):
-    system = SystemSettings(extended_mode=None, save_raw=True, save_thumbnail_image=False, magic_variable=False)
+    system = SystemSettings(extended_mode=None, save_raw=False, save_nonshared_raw=True, save_thumbnail_image=False, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     expected_text = Config(system=system, multidata_tile=multi)
     valid_dir = Path("tasksupport")
@@ -295,7 +300,7 @@ def test_invalid_get_config_empty_yml(invalid_empty_config_yaml):
 
 
 def test_load_config_with_config():
-    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_thumbnail_image=False, magic_variable=False)
+    system = SystemSettings(extended_mode="rdeformat", save_raw=True, save_nonshared_raw=True, save_thumbnail_image=False, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     config = Config(system=system, multidata_tile=multi)
     task_support = Path("tasksupport")
@@ -305,7 +310,7 @@ def test_load_config_with_config():
 
 def test_load_config_without_config(tasksupport):
     tasksupport_path = Path("data/tasksupport")
-    system = SystemSettings(extended_mode=None, save_raw=True, save_thumbnail_image=True, magic_variable=False)
+    system = SystemSettings(extended_mode=None, save_raw=True, save_nonshared_raw=True, save_thumbnail_image=True, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     config = Config(system=system, multidata_tile=multi)
     result = load_config(tasksupport_path)
@@ -314,7 +319,7 @@ def test_load_config_without_config(tasksupport):
 
 def test_load_config_with_none_config_and_none_get_config():
     dummpy_path = Path("tasksupport")
-    system = SystemSettings(extended_mode=None, save_raw=True, save_thumbnail_image=False, magic_variable=False)
+    system = SystemSettings(extended_mode=None, save_raw=False, save_nonshared_raw=True, save_thumbnail_image=False, magic_variable=False)
     multi = MultiDataTileSettings(ignore_errors=False)
     config = Config(system=system, multidata_tile=multi)
     result = load_config(dummpy_path)

--- a/tests/test_invoicefile.py
+++ b/tests/test_invoicefile.py
@@ -185,6 +185,7 @@ def rde_resource():
         invoice=Path("data/invoice"),
         invoice_schema_json=Path("data/tasksupport/invoice.schema.json"),
         invoice_org=Path("data/invoice/invoice.json"),
+        nonshared_raw=Path("dummmy"),
     )
     yield rde_resource
 

--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ skip_install = true
 deps = -rrequirements-dev.lock
 commands =
   # Due to not having been able to refactor.
-  lizard src/rdetoolkit/workflows.py -C 13
+  lizard src/rdetoolkit/workflows.py -C 16
   lizard src/rdetoolkit/__main__.py -C 10
   lizard src/rdetoolkit/  -C 10 -x src/rdetoolkit/workflows.py -x src/rdetoolkit/__main__.py
 
@@ -85,7 +85,7 @@ skip_install = true
 deps = -rrequirements-dev.lock
 commands =
   # Due to not having been able to refactor.
-  lizard src/rdetoolkit/workflows.py -C 13
+  lizard src/rdetoolkit/workflows.py -C 16
   lizard src/rdetoolkit/__main__.py -C 10
   lizard src/rdetoolkit/  -C 10 -x src/rdetoolkit/workflows.py -x src/rdetoolkit/__main__.py
 
@@ -94,7 +94,7 @@ skip_install = true
 deps = -rrequirements-dev.lock
 commands =
   # Due to not having been able to refactor.
-  lizard src/rdetoolkit/workflows.py -C 13
+  lizard src/rdetoolkit/workflows.py -C 16
   lizard src/rdetoolkit/__main__.py -C 10
   lizard src/rdetoolkit/  -C 10 -x src/rdetoolkit/workflows.py -x src/rdetoolkit/__main__.py
 
@@ -103,7 +103,7 @@ skip_install = true
 deps = -rrequirements-dev.lock
 commands =
   # Due to not having been able to refactor.
-  lizard src/rdetoolkit/workflows.py -C 13
+  lizard src/rdetoolkit/workflows.py -C 16
   lizard src/rdetoolkit/__main__.py -C 10
   lizard src/rdetoolkit/  -C 10 -x src/rdetoolkit/workflows.py -x src/rdetoolkit/__main__.py
 
@@ -114,7 +114,7 @@ deps =
     -rrequirements-dev.lock
 commands =
   # Due to not having been able to refactor.
-  lizard src/rdetoolkit/workflows.py -C 13
+  lizard src/rdetoolkit/workflows.py -C 16
   lizard src/rdetoolkit/__main__.py -C 10
   lizard src/rdetoolkit/  -C 10 -x src/rdetoolkit/workflows.py -x src/rdetoolkit/__main__.py
 


### PR DESCRIPTION
## issue
<!--関連issueを記載する-->
#48 : 生データ格納先をデフォルトでnonshared_rawに変更する

## 変更内容
<!--対応内容や変更内容を記載する-->
- #48 : 生データ格納先をデフォルトでnonshared_rawに変更
  - models/rde2types.py: RdeOutputResourcePathのnonshared_rawは、Noneを許容しない
  - modeproc.py: 各モードにnonshared_rawへファイルをコピーする機能を実装
  - models/config.py: デフォルトの設定でsave_rawはFalseに変更
  - models/config.py: デフォルトの設定でsave_nonshared_rawのフィールドを追加・デフォルトをTrueに変更
- 上記の変更に伴い、`docs/usage/config/config.md`を更新
- 上記の変更に伴い、`docs/usage/structured_process/structured.md`を更新

## 検証内容
<!--プルリクで確認する内容を列挙する-->

- [ ] CIのテストがパスする
- [ ] 対象のスクリプトの変更に問題がないか
