### PR TITLE
Remove sccache option from pypi-release workflow

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -6,14 +6,19 @@ jobs:
   cleanup:
     runs-on: ubuntu-latest
     steps:
+      - name: Install GitHub CLI
+        uses: actions/setup-node@v3
+        with:
+          node-version: "14"
+      - name: Install GitHub CLI Cache Extension
+        run: gh extension install actions/gh-actions-cache
       - name: Cleanup
         run: |
-          gh extension install actions/gh-actions-cache
           set +e
-          echo "Deleting caches..."
+          echo "Deleting all caches..."
           gh actions-cache list -R $REPO -L 100 | while IFS=$'\t' read -r cacheKey _ branch _
           do
-            gh actions-cache delete "$cacheKey" -R $REPO -B "$branch" --confirm
+            gh actions-cache delete "$cacheKey" -R $REPO --confirm
           done
           echo "Done"
         env:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -12,11 +12,13 @@ jobs:
           node-version: "14"
       - name: Install GitHub CLI Cache Extension
         run: gh extension install actions/gh-actions-cache
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Cleanup
         run: |
           set +e
           echo "Deleting all caches..."
-          gh actions-cache list -R $REPO -L 100 | while IFS=$'\t' read -r cacheKey _ branch _
+          gh actions-cache list -R $REPO -L 100 | while IFS=$'\t' read -r cacheKey _
           do
             gh actions-cache delete "$cacheKey" -R $REPO --confirm
           done

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -171,7 +171,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
-          sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -210,7 +209,6 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
-          sccache: "true"
       - name: Upload wheel
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Eliminate the sccache option from the pypi-release workflow to streamline the build process.