### PR TITLE
Update contributing guidelines and enhance logging functionality

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ rdetoolkitのドキュメントは、本リポジトリの`docs`フォルダに�
 ドキュメント更新に関して知っておくべき重要事項について:
 
 - rdetoolkitのドキュメントは、コード自体のdocstringと、その他のドキュメントの2つに大別されます。
-- docstringは、各種モジュールの利用法が記載され、GitLab CI/CDで、自動ビルドされドキュメントが更新されます。
+- docstringは、各種モジュールの利用法が記載され、GitHub Actionsで、自動ビルドされドキュメントが更新されます。
 - docstringは、**Google Style**で記述してください。
   - 参考: [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
 
@@ -124,7 +124,7 @@ Github Pagesに掲載しています。
 
 ### Issueを作成する
 
-問題や不具合が発生した場合、以下のisuueへ起票お願いします。この時、ラベルは`Type:improvement`, `Type: new feature`のどちらかの付与をお願いします。
+問題や不具合が発生した場合、以下のisuueへの書き込みをお願いします。
 
 > <https://github.com/nims-dpfc/rdetoolkit/issues>
 
@@ -132,11 +132,31 @@ Github Pagesに掲載しています。
 
 新しい機能や修正を行う際は、新しいブランチを作成してください。
 
-- ブランチ名の接頭辞は、`develop-v<x.y.z>`というブランチから、末尾に任意の文字列を追加して作成してください。
+- ブランチ名の接頭辞は、`develop/v<x.y.z>`というブランチから、末尾に任意の文字列を追加して作成してください。
 
 ```shell
-git checkout -b develop-v<x.y.z>-<任意の機能名など> origin/develop-v<x.y.z>
+git checkout -b develop/v<x.y.z>/<任意の機能名など> origin/develop/v<x.y.z>
 ```
+
+**接頭辞の例**
+
+| **接頭辞**    | **意味**                                   | **例**                           |
+| ------------- | ------------------------------------------ | -------------------------------- |
+| `feature/`    | 新機能の開発                               | `feature/user-authentication`    |
+| `bugfix/`     | バグ修正                                   | `bugfix/login-error`             |
+| `fix/`        | バグ修正（`bugfix/`と同様）                | `fix/login-error`                |
+| `hotfix/`     | 緊急の修正が必要な場合                     | `hotfix/critical-security-issue` |
+| `release/`    | リリース準備やバージョン管理               | `release/v1.2.0`                 |
+| `chore/`      | コードのリファクタリングやメンテナンス作業 | `chore/update-dependencies`      |
+| `experiment/` | 試験的な機能やアイデアの検証               | `experiment/new-ui-concept`      |
+| `docs/`       | ドキュメントの更新                         | `docs/update-readme`             |
+| `test/`       | テスト関連の変更                           | `test/add-unit-tests`            |
+| `refactor/`   | コードのリファクタリング                   | `refactor/cleanup-auth-module`   |
+| `ci/`         | 継続的インテグレーション設定の変更         | `ci/update-github-actions`       |
+| `style/`      | コードのスタイルやフォーマットの変更       | `style/format-codebase`          |
+| `perf/`       | パフォーマンス改善                         | `perf/optimize-db-queries`       |
+| `design/`     | デザイン関連の変更                         | `design/update-mockups`          |
+| `security/`   | セキュリティ関連の修正や強化               | `security/enhance-encryption`    |
 
 ### 新機能・修正を加える
 
@@ -168,7 +188,7 @@ tox
 ```shell
 git add .
 git commit -m "#[issue番号] [変更内容の簡単な説明]"
-git push origin develop-v<x.y.z>-<先ほどつけた名称>
+git push origin develop-v<x.y.z>/<任意の名称>
 ```
 
 もし、pre-commitのチェックでコミットできない場合、全てのエラーを解消した上でコミットをお願いします。

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@ These are the contributors to this project!
 - Hiroaki Tosaka
 - Hitoshi Enami
 - Kumiko Sasajima
+- SASAJIMA Kumiko

--- a/docs/rdetoolkit/rdelogger.md
+++ b/docs/rdetoolkit/rdelogger.md
@@ -2,6 +2,14 @@
 
 `rdelogger `is used to collect execution logs of the structuring process.
 
+## LazyFileHandler
+
+::: src.rdetoolkit.rdelogger.LazyFileHandler
+    options:
+        members:
+            - _ensure_handler
+            - emit
+
 ## get_logger
 
 ::: src.rdetoolkit.rdelogger.get_logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rdetoolkit"
-version = "1.0.3"
+version = "1.0.4"
 description = "A module that supports the workflow of the RDE dataset construction program"
 authors = [{ name = "Sonokawa Hayato", email = "SONOKAWA.Hayato@nims.go.jp" }]
 keywords = ["rdetoolkit", "RDE", "toolkit", "structure", "dataset"]

--- a/src/rdetoolkit.pyi
+++ b/src/rdetoolkit.pyi
@@ -1,4 +1,0 @@
-from .impl import *
-from .interfaces import *
-
-__version__: str

--- a/src/rdetoolkit/__init__.py
+++ b/src/rdetoolkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 from rdetoolkit.core import resize_image_aspect_ratio
 

--- a/src/rdetoolkit/rdelogger.py
+++ b/src/rdetoolkit/rdelogger.py
@@ -89,9 +89,6 @@ def get_logger(name: str, *, file_path: RdeFsPath | None = None) -> logging.Logg
     if file_path is None:
         return logger
 
-    # add a file handler
-    if not os.path.exists(os.path.dirname(file_path)):
-        os.makedirs(os.path.dirname(file_path), exist_ok=True)
     file_handler = LazyFileHandler(str(file_path))
     file_handler.setLevel(logging.DEBUG)
     file_handler.setFormatter(formatter)

--- a/src/rdetoolkit/rdelogger.pyi
+++ b/src/rdetoolkit/rdelogger.pyi
@@ -5,6 +5,13 @@ from rdetoolkit.models.rde2types import RdeFsPath as RdeFsPath
 from rdetoolkit.rde2util import StorageDir as StorageDir
 from typing import Callable
 
+class LazyFileHandler(logging.Handler):
+    filename: Incomplete
+    mode: Incomplete
+    encoding: Incomplete
+    def __init__(self, filename: str, mode: str = 'a', encoding: str = 'utf-8') -> None: ...
+    def emit(self, record: logging.LogRecord) -> None: ...
+
 def get_logger(name: str, *, file_path: RdeFsPath | None = None) -> logging.Logger: ...
 
 class CustomLog:

--- a/src/rdetoolkit/workflows.py
+++ b/src/rdetoolkit/workflows.py
@@ -173,11 +173,14 @@ def run(*, custom_dataset_function: _CallbackType | None = None, config: Config 
 
         ```python
         ### main.py
-        from rdetoolkit.config import Config
+        from rdetoolkit.config import Config, MultiDataTileSettings, SystemSettings
         from rdetoolkit import workflow
         from custom import custom_dataset # User-defined structuring processing function
 
-        cfg = Config(extended_mode="rdeformat", save_raw=True, save_main_image=False, save_thumbnail_image=False, magic_variable=False)
+        cfg = Config(
+            system=SystemSettings(extended_mode="MultiDataTile", save_raw=False, save_nonshared_raw=True, save_thumbnail_image=True),
+            multidata_tile=MultiDataTileSettings(ignore_errors="False")
+        )
         workflow.run(custom_dataset_function=custom_dataset, config=cfg) # Execute structuring process
         ```
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,7 +86,7 @@ def test_make_requirements_txt():
 # ex.
 # pandas==2.0.3
 # numpy
-rdetoolkit==1.0.3
+rdetoolkit==1.0.4
 """
     assert content == expected_content
     test_path.unlink()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,9 +3,12 @@ import logging.handlers
 import os
 import pathlib
 import shutil
+from typing import Generator
 from unittest import mock
 
-from rdetoolkit.rdelogger import get_logger, CustomLog, log_decorator
+import pytest
+
+from rdetoolkit.rdelogger import get_logger, CustomLog, log_decorator, LazyFileHandler
 
 
 def test_custom_log():
@@ -51,8 +54,186 @@ def test_get_logger_with_filepath():
     logger = get_logger(name, file_path=filepath)
     assert logger.name == name
     assert len(logger.handlers) == 1
-    assert isinstance(logger.handlers[0], logging.FileHandler)
-    assert pathlib.Path(logger.handlers[0].baseFilename) == pathlib.Path(filepath)
+    assert isinstance(logger.handlers[0], LazyFileHandler)
 
     if os.path.exists(test_dir):
         shutil.rmtree(test_dir)
+
+
+@pytest.fixture
+def tmp_path():
+    yield pathlib.Path("tmp_tests")
+
+    if os.path.exists("tmp_tests"):
+        shutil.rmtree("tmp_tests")
+
+
+def test_get_logger_without_file():
+    """Test logger creation without file path"""
+    logger = get_logger("test_logger")
+
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == "test_logger"
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 0
+
+
+def test_get_logger_with_file(tmp_path):
+    """Test logger creation with file path"""
+    log_file = tmp_path / "test.log"
+    logger = get_logger("test_logger", file_path=log_file)
+
+    assert isinstance(logger, logging.Logger)
+    assert logger.name == "test_logger"
+    assert logger.level == logging.DEBUG
+    assert len(logger.handlers) == 1
+    assert isinstance(logger.handlers[0], LazyFileHandler)
+
+    # Test log writing
+    test_message = "Test debug message"
+    logger.debug(test_message)
+
+    assert log_file.exists()
+    content = log_file.read_text()
+    assert test_message in content
+    assert "[test_logger](DEBUG)" in content
+
+
+def test_get_logger_creates_directory(tmp_path):
+    """Test logger creates directory structure if not exists"""
+    log_dir = tmp_path / "logs" / "subdir"
+    log_file = log_dir / "test.log"
+
+    assert not log_dir.exists()
+
+    logger = get_logger("test_logger", file_path=log_file)
+    logger.debug("Test message")
+
+    assert log_dir.exists()
+    assert log_file.exists()
+
+
+def test_get_logger_formatter():
+    """Test logger formatter"""
+    logger = get_logger("test_logger")
+
+    assert logger.handlers == []
+    for handler in logger.handlers:
+        formatter = handler.formatter
+        assert formatter._fmt == "%(asctime)s - [%(name)s](%(levelname)s) - %(message)s"
+
+
+@pytest.fixture(autouse=True)
+def cleanup_logger():
+    """各テストの前後でロガーのハンドラーをクリアする"""
+    logger = logging.getLogger("test_logger")
+    logger.handlers.clear()
+
+    yield
+
+    # テスト後のクリーンアップ
+    logger.handlers.clear()
+
+
+@pytest.fixture
+def temp_log_file() -> Generator[str, None, None]:
+    """一時的なログファイルのパスを提供するフィクスチャ。
+
+    Args:
+        tmp_path: Pytestが提供する一時ディレクトリのPath
+
+    Yields:
+        str: 一時的なログファイルのパス
+    """
+    tmp_path = pathlib.Path(__file__).parent / "logs"
+    log_path = tmp_path / "test_logs" / "test.log"
+    yield str(log_path)
+
+    if log_path.exists():
+        log_path.unlink()
+    if log_path.parent.exists():
+        log_path.parent.rmdir()
+
+
+class TestLazyFileHandler:
+    def test_init(self, temp_log_file: str) -> None:
+        handler = LazyFileHandler(temp_log_file)
+
+        assert handler.filename == temp_log_file
+        assert handler.mode == "a"
+        assert handler.encoding == "utf-8"
+        assert handler._handler is None
+        assert not os.path.exists(temp_log_file)
+
+    def test_emit_creates_file(self, temp_log_file: str) -> None:
+        handler = LazyFileHandler(temp_log_file)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=42,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+        handler.emit(record)
+        assert handler._handler is not None
+
+    def test_multiple_emit_calls(self, temp_log_file: str) -> None:
+        """複数回のemitが呼び出しで同じハンドラーが再利用されることを確認するテスト"""
+        handler = LazyFileHandler(temp_log_file)
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=42,
+            msg="Test message",
+            args=(),
+            exc_info=None,
+        )
+        handler.emit(record)
+        first_handler = handler._handler
+        handler.emit(record)
+        assert handler._handler is first_handler
+
+    def test_costom_mode_and_encoding(self, temp_log_file) -> None:
+        """存在しないディレクトリが自動的に作成されることを確認するテスト"""
+        deep_path = pathlib.Path("tests", "deep", "nested", "dir", "test.log")
+        handler = LazyFileHandler(str(deep_path))
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.DEBUG,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None
+        )
+
+        handler.emit(record)
+
+        assert deep_path.exists()
+        assert deep_path.parent.exists()
+
+    def test_formatter_and_level_propagation(self, temp_log_file: str) -> None:
+        """フォーマッターとログレベルが正しく伝播することを確認するテスト"""
+        handler = LazyFileHandler(temp_log_file)
+        formatter = logging.Formatter("%(message)s")
+        handler.setFormatter(formatter)
+        handler.setLevel(logging.WARNING)
+
+        record = logging.LogRecord(
+            name="test_logger",
+            level=logging.WARNING,
+            pathname="test.py",
+            lineno=1,
+            msg="Test message",
+            args=(),
+            exc_info=None
+        )
+
+        handler.emit(record)
+
+        assert handler._handler is not None
+        assert handler._handler.formatter == formatter
+        assert handler._handler.level == logging.WARNING


### PR DESCRIPTION
## issue
<!--関連issueを記載する-->
- Fixes #87
- Fixes #88
- Fixes #89

## 変更内容
<!--対応内容や変更内容を記載する-->

This update addresses two main issues: first, it corrects the contributing guidelines to reflect the use of GitHub Actions instead of GitLab for documentation builds. Second, it introduces the `LazyFileHandler` for lazy initialization of log file handling, preventing unnecessary log file creation during the initialization process. Additionally, unit tests for the new logging functionality are added, and the version is updated to 1.0.4 across relevant files.

- Fixes #87
  - GitLabの文言を削除
- Fixes #88
  - `rdetoolkit init`実行時に予期しない箇所でlogフォルダが生成されるため内部の処理を変更
- Fixes #89  
  - main.py内でのコンフィグ設定方法に関するドキュメントを更新

## 検証内容
<!--プルリクで確認する内容を列挙する-->

- [ ] CIのテストがパスする
- [ ] 対象のスクリプトの変更に問題がないか