### PR TITLE
fix: #91 initialize obj as an empty dictionary in MetadataDefJsonGenerator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,14 @@
-## issue
-<!--関連issueを記載する-->
+## Related Issue
+<!--Please specify the related issue(s)-->
 
-## 変更内容
-<!--対応内容や変更内容を記載する-->
+## Changes
+<!--Describe the implementation details and changes made-->
 
-## 実施していない内容
-<!--今回の変更で対応しない・できない内容を記載する-->
+## Out of Scope
+<!--List any items that are not addressed or out of scope for this change-->
 
-以下、バリデーション機能で不具合の指摘が上がっているが、本件対応内容や変更方針がまとまっていないため、次回のバージョンに回す。また以下の追加機能も次回のバージョンに回す。
+## Verification
+<!--List the items to be verified in this pull request-->
 
-## 検証内容
-<!--プルリクで確認する内容を列挙する-->
-
-- [ ] CIのテストがパスする
-- [ ] 対象のスクリプトの変更に問題がないか
+- [ ] CI tests pass successfully
+- [ ] No issues with the modified scripts

--- a/src/rdetoolkit/cmd/command.py
+++ b/src/rdetoolkit/cmd/command.py
@@ -252,7 +252,7 @@ class MetadataDefJsonGenerator:
         """
         matadata_def_path = Path(self.path) if isinstance(self.path, str) else self.path
 
-        obj: dict[str, Any] = {"constant": {}, "variable": []}
+        obj: dict[str, Any] = {}
 
         with open(matadata_def_path, mode="w", encoding="utf-8") as f:
             json.dump(obj, f, indent=4, ensure_ascii=False)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 import shutil
@@ -127,6 +128,10 @@ def test_make_metadata_def_json():
     gen = MetadataDefJsonGenerator(test_path)
     gen.generate()
 
+    with open(test_path, encoding="utf-8") as f:
+        contents = json.load(f)
+
+    assert contents == {}
     assert test_path.exists()
     test_path.unlink()
 


### PR DESCRIPTION
## issue
<!--関連issueを記載する-->
- #91

## 変更内容
- #91 Changed initial values in metadata.json
  - The init command was outputting values different from the metadata definition.

## 検証内容
<!--プルリクで確認する内容を列挙する-->

- [ ] CIのテストがパスする
- [ ] 対象のスクリプトの変更に問題がないか
