### PR TITLE
fix: update Sigstore action version to v3.0.0 in PyPI release workflow

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -310,7 +310,7 @@ jobs:
         with:
           path: dist/
       - name: Sign the distribution 📦 with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
           inputs: >-
             dist/**/*.whl


### PR DESCRIPTION
This pull request includes an update to the `pypi-release` workflow to use the latest version of the Sigstore GitHub Action.

* [`.github/workflows/pypi-release.yml`](diffhunk://#diff-cd1f17b21b16e3d73b40849fa2eda95b55ec846d667fb026a98b0c50884b204aL313-R313): Updated the Sigstore GitHub Action from version `v2.1.1` to `v3.0.0`.## Related Issue
